### PR TITLE
Fix a crash and small issues with the overlay window

### DIFF
--- a/AimmyWPF/OverlayWindow.xaml
+++ b/AimmyWPF/OverlayWindow.xaml
@@ -6,6 +6,6 @@
         ShowInTaskbar="False"
         Closing="Window_Closing">
     <Canvas Name="OverlayCanvas">
-        <Ellipse x:Name="OverlayRectangle" Stroke="Red" StrokeThickness="1" />
+        <Ellipse x:Name="OverlayCircle" Stroke="Red" StrokeThickness="1" />
     </Canvas>
 </Window>

--- a/AimmyWPF/OverlayWindow.xaml
+++ b/AimmyWPF/OverlayWindow.xaml
@@ -2,7 +2,9 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         WindowStyle="None" AllowsTransparency="True" Background="Transparent"
-        Topmost="True">
+        Topmost="True"
+        ShowInTaskbar="False"
+        Closing="Window_Closing">
     <Canvas Name="OverlayCanvas">
         <Ellipse x:Name="OverlayRectangle" Stroke="Red" StrokeThickness="1" />
     </Canvas>

--- a/AimmyWPF/OverlayWindow.xaml.cs
+++ b/AimmyWPF/OverlayWindow.xaml.cs
@@ -27,9 +27,9 @@ namespace AimmyWPF
 
         private void Timer_Tick(object sender, EventArgs e)
         {
-            // Update rectangle dimensions.
-            OverlayRectangle.Width = FovSize;
-            OverlayRectangle.Height = FovSize;
+            // Update circle dimensions.
+            OverlayCircle.Width = FovSize;
+            OverlayCircle.Height = FovSize;
 
             // Get screen dimensions.
             double screenWidth = SystemParameters.PrimaryScreenWidth;
@@ -39,9 +39,9 @@ namespace AimmyWPF
             OverlayCanvas.Width = screenWidth;
             OverlayCanvas.Height = screenHeight;
 
-            // Update rectangle position within the Canvas.
-            Canvas.SetLeft(OverlayRectangle, (screenWidth - FovSize) / 2);
-            Canvas.SetTop(OverlayRectangle, (screenHeight - FovSize) / 2);
+            // Update circle position within the Canvas.
+            Canvas.SetLeft(OverlayCircle, (screenWidth - FovSize) / 2);
+            Canvas.SetTop(OverlayCircle, (screenHeight - FovSize) / 2);
 
             // Update OverlayWindow position to be centered on the screen.
             this.Left = 0;

--- a/AimmyWPF/OverlayWindow.xaml.cs
+++ b/AimmyWPF/OverlayWindow.xaml.cs
@@ -49,5 +49,11 @@ namespace AimmyWPF
             this.Width = screenWidth;
             this.Height = screenHeight;
         }
+
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            e.Cancel = true;
+            this.Hide();
+        }
     }
 }


### PR DESCRIPTION
This fixes some issues with the FOV overlay window and renames `OverlayRectangle` to `OverlayCircle` to match what it is. I also noticed that the circle captures clicks and the window can be focused even though it's supposed to be an overlay, but after some research and trial and error it doesn't look like I can fix that without importing `user32.dll` directly. Let me know if you'd like me to try making those changes, though.