### PR TITLE
Allow minimizing from the taskbar

### DIFF
--- a/AimmyWPF/MainWindow.xaml
+++ b/AimmyWPF/MainWindow.xaml
@@ -11,7 +11,7 @@
         Width="564"
         WindowStyle="None"
         Topmost="True"
-        ResizeMode="NoResize"
+        ResizeMode="CanMinimize"
         WindowStartupLocation="CenterScreen"
         AllowsTransparency="True"
         Background="Transparent"


### PR DESCRIPTION
I assume it's not intended behavior that you can't minimize Aimmy in any way other than clicking the minimize button, so I changed `ResizeMode` to `CanMinimize`.