### PR TITLE
Aim at center of bounding box/Y axis movement fix for ultrawide monitors

### DIFF
--- a/AimmyWPF/MainWindow.xaml.cs
+++ b/AimmyWPF/MainWindow.xaml.cs
@@ -313,8 +313,8 @@ namespace AimmyWPF
 
                 double YOffset = aimmySettings["Y_Offset"];
                 double XOffset = aimmySettings["X_Offset"];
-                int detectedX = (int)((closestPrediction.Rectangle.X * scaleX) + XOffset);
-                int detectedY = (int)((closestPrediction.Rectangle.Y * scaleY) + YOffset);
+                int detectedX = (int)((closestPrediction.Rectangle.X + closestPrediction.Rectangle.Width / 2) * scaleX + XOffset);
+                int detectedY = (int)((closestPrediction.Rectangle.Y + closestPrediction.Rectangle.Height / 2) * scaleY + YOffset);
 
                 // Handle Prediction
                 if (toggleState["PredictionToggle"])

--- a/AimmyWPF/MainWindow.xaml.cs
+++ b/AimmyWPF/MainWindow.xaml.cs
@@ -271,6 +271,10 @@ namespace AimmyWPF
             int targetX = detectedX - halfScreenWidth;
             int targetY = detectedY - halfScreenHeight;
 
+            // Aspect ratio correction factor
+            double aspectRatioCorrection = (double)ScreenWidth / ScreenHeight;
+            targetY = (int)(targetY * aspectRatioCorrection);
+
             // Introduce random jitter
             int jitterX = MouseRandom.Next(-4, 4);
             int jitterY = MouseRandom.Next(-4, 4);


### PR DESCRIPTION
Aims at the center of bounding box instead of top left corner. makes aim snap less when detections are made from the bottom/right side of FOV area. Also Y axis moves slower than X axis in Aimmy. I think it only happens on ultrawide monitors but I have a feeling it actually happens on all of them. Its just less noticiable at 16:9. If you make the sensitivity quite slow you can see it right away. Pushed code to fix it.