### PR TITLE
EMA Smoothening System & Bug Fixes

### DIFF
--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -364,6 +364,8 @@ namespace Aimmy2.AILogic
                     DetectedPlayerOverlay.DetectedTracers.Opacity = 0;
                 }
 
+                DetectedPlayerOverlay.Opacity = Dictionary.sliderSettings["Opacity"];
+
                 DetectedPlayerOverlay.DetectedPlayerFocus.Opacity = 1;
                 DetectedPlayerOverlay.DetectedPlayerFocus.Margin = new Thickness(Convert.ToInt16(LastDetectionBox.X / WinAPICaller.scalingFactorX),
                     Convert.ToInt16(LastDetectionBox.Y / WinAPICaller.scalingFactorY),

--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -359,6 +359,9 @@ namespace Aimmy2.AILogic
                     DetectedPlayerOverlay.DetectedTracers.Opacity = 1;
                     DetectedPlayerOverlay.DetectedTracers.X2 = Convert.ToInt16(LastDetectionBox.X / WinAPICaller.scalingFactorX) + (LastDetectionBox.Width / 2);
                     DetectedPlayerOverlay.DetectedTracers.Y2 = Convert.ToInt16(LastDetectionBox.Y / WinAPICaller.scalingFactorY) + LastDetectionBox.Height;
+                }else if (!Dictionary.toggleState["Show Tracers"])
+                {
+                    DetectedPlayerOverlay.DetectedTracers.Opacity = 0;
                 }
 
                 DetectedPlayerOverlay.DetectedPlayerFocus.Opacity = 1;

--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -359,7 +359,8 @@ namespace Aimmy2.AILogic
                     DetectedPlayerOverlay.DetectedTracers.Opacity = 1;
                     DetectedPlayerOverlay.DetectedTracers.X2 = Convert.ToInt16(LastDetectionBox.X / WinAPICaller.scalingFactorX) + (LastDetectionBox.Width / 2);
                     DetectedPlayerOverlay.DetectedTracers.Y2 = Convert.ToInt16(LastDetectionBox.Y / WinAPICaller.scalingFactorY) + LastDetectionBox.Height;
-                }else if (!Dictionary.toggleState["Show Tracers"])
+                }
+                else if (!Dictionary.toggleState["Show Tracers"])
                 {
                     DetectedPlayerOverlay.DetectedTracers.Opacity = 0;
                 }

--- a/Aimmy2/Class/Dictionary.cs
+++ b/Aimmy2/Class/Dictionary.cs
@@ -1,4 +1,4 @@
-﻿using Visuality;
+using Visuality;
 
 namespace Aimmy2.Class
 {
@@ -32,6 +32,7 @@ namespace Aimmy2.Class
             { "Y Offset (%)", 50 },
             { "X Offset (Left/Right)", 0 },
             { "X Offset (%)", 50 },
+            { "EMA Smoothening", 0.5},
             { "Auto Trigger Delay", 0.1 },
             { "AI Minimum Confidence", 45 },
             { "AI Confidence Font Size", 20 },
@@ -47,6 +48,7 @@ namespace Aimmy2.Class
             { "Aim Assist", false },
             { "Constant AI Tracking", false },
             { "Predictions", false },
+            { "EMA Smoothening", false },
             { "Enable Model Switch Keybind", true },
             { "Enable Gun Switching Keybind", false },
             { "Auto Trigger", false },
@@ -62,7 +64,6 @@ namespace Aimmy2.Class
             { "LG HUB Mouse Movement", false },
             { "Mouse Background Effect", true },
             { "UI TopMost", true },
-
             { "X Axis Percentage Adjustment", false },
             { "Y Axis Percentage Adjustment", false }
         };

--- a/Aimmy2/InputLogic/MouseManager.cs
+++ b/Aimmy2/InputLogic/MouseManager.cs
@@ -1,4 +1,4 @@
-﻿using Aimmy2.Class;
+using Aimmy2.Class;
 using Aimmy2.MouseMovementLibraries.GHubSupport;
 using Class;
 using MouseMovementLibraries.ddxoftSupport;
@@ -6,6 +6,7 @@ using MouseMovementLibraries.RazerSupport;
 using MouseMovementLibraries.SendInputSupport;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Security.RightsManagement;
 
 namespace InputLogic
 {
@@ -14,14 +15,17 @@ namespace InputLogic
         private static readonly double ScreenWidth = WinAPICaller.ScreenWidth;
         private static readonly double ScreenHeight = WinAPICaller.ScreenHeight;
 
-        //private int TimeSinceLastClick = 0;
         private static DateTime LastClickTime = DateTime.MinValue;
-
         private static int LastAntiRecoilClickTime = 0;
 
         private const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
         private const uint MOUSEEVENTF_LEFTUP = 0x0004;
         private const uint MOUSEEVENTF_MOVE = 0x0001;
+        private static double previousX = 0;
+        private static double previousY = 0;
+        public static double smoothingFactor = 0.5;
+        public static bool IsEMASmoothingEnabled = false;
+
 
         [DllImport("user32.dll")]
         private static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, int dwExtraInfo);
@@ -36,10 +40,21 @@ namespace InputLogic
 
             double x = uu * u * start.X + 3 * uu * t * control1.X + 3 * u * tt * control2.X + tt * t * end.X;
             double y = uu * u * start.Y + 3 * uu * t * control1.Y + 3 * u * tt * control2.Y + tt * t * end.Y;
+            if (IsEMASmoothingEnabled) { 
+            double smoothedX = EmaSmoothing(previousX, x, smoothingFactor);
+            double smoothedY = EmaSmoothing(previousY, y, smoothingFactor);
+
+            x = smoothedX;
+            y = smoothedY;
+            }
 
             return new Point((int)x, (int)y);
         }
 
+        private static double EmaSmoothing(double previousValue, double currentValue, double smoothingFactor)
+        {
+            return (currentValue * smoothingFactor) + (previousValue * (1 - smoothingFactor));
+        }
         public static async Task DoTriggerClick()
         {
             int timeSinceLastClick = (int)(DateTime.UtcNow - LastClickTime).TotalMilliseconds;
@@ -94,7 +109,6 @@ namespace InputLogic
         {
             int timeSinceLastClick = Math.Abs(DateTime.UtcNow.Millisecond - LastAntiRecoilClickTime);
 
-            //Debug.WriteLine(timeSinceLastClick);
             if (timeSinceLastClick < Dictionary.AntiRecoilSettings["Fire Rate"])
             {
                 return;
@@ -131,8 +145,6 @@ namespace InputLogic
 
         public static void MoveCrosshair(int detectedX, int detectedY)
         {
-            #region Variables
-
             int halfScreenWidth = (int)ScreenWidth / 2;
             int halfScreenHeight = (int)ScreenHeight / 2;
 
@@ -151,10 +163,6 @@ namespace InputLogic
             Point control2 = new(start.X + 2 * (end.X - start.X) / 3, start.Y + 2 * (end.Y - start.Y) / 3);
             Point newPosition = CubicBezier(start, end, control1, control2, 1 - Dictionary.sliderSettings["Mouse Sensitivity (+/-)"]);
 
-            #endregion Variables
-
-            #region Variable Changes
-
             targetX = Math.Clamp(targetX, -150, 150);
             targetY = Math.Clamp(targetY, -150, 150);
 
@@ -162,8 +170,6 @@ namespace InputLogic
 
             targetX += jitterX;
             targetY += jitterY;
-
-            #endregion Variable Changes
 
             switch (Dictionary.dropdownState["Mouse Movement Method"])
             {

--- a/Aimmy2/InputLogic/MouseManager.cs
+++ b/Aimmy2/InputLogic/MouseManager.cs
@@ -52,6 +52,8 @@ namespace InputLogic
 
         private static double EmaSmoothing(double previousValue, double currentValue, double smoothingFactor)
         {
+            // I Dont like math so I use copilot for this
+            // whip
             return (currentValue * smoothingFactor) + (previousValue * (1 - smoothingFactor));
         }
         public static async Task DoTriggerClick()

--- a/Aimmy2/InputLogic/MouseManager.cs
+++ b/Aimmy2/InputLogic/MouseManager.cs
@@ -6,7 +6,6 @@ using MouseMovementLibraries.RazerSupport;
 using MouseMovementLibraries.SendInputSupport;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using System.Security.RightsManagement;
 
 namespace InputLogic
 {

--- a/Aimmy2/MainWindow.xaml.cs
+++ b/Aimmy2/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Aimmy2.Class;
+using Aimmy2.Class;
 using Aimmy2.MouseMovementLibraries.GHubSupport;
 using Aimmy2.Other;
 using Aimmy2.UILibrary;
@@ -11,6 +11,7 @@ using MouseMovementLibraries.RazerSupport;
 using Other;
 using System.Diagnostics;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -325,6 +326,10 @@ namespace Aimmy2
                 case "UI TopMost":
                     Topmost = Dictionary.toggleState[title];
                     break;
+                case "EMA Smoothening":
+                    MouseManager.IsEMASmoothingEnabled = Dictionary.toggleState[title];
+                    Debug.WriteLine(MouseManager.IsEMASmoothingEnabled);
+                    break;
             }
         }
 
@@ -580,6 +585,7 @@ namespace Aimmy2
                 }
             };
             uiManager.T_Predictions = AddToggle(AimAssist, "Predictions");
+            uiManager.T_EMASmoothing = AddToggle(AimAssist, "EMA Smoothening");
             uiManager.C_EmergencyKeybind = AddKeyChanger(AimAssist, "Emergency Stop Keybind", Dictionary.bindingSettings["Emergency Stop Keybind"]);
             uiManager.T_EnableModelSwitchKeybind = AddToggle(AimAssist, "Enable Model Switch Keybind");
             uiManager.C_ModelSwitchKeybind = AddKeyChanger(AimAssist, "Model Switch Keybind", Dictionary.bindingSettings["Model Switch Keybind"]);
@@ -629,6 +635,8 @@ namespace Aimmy2
 
             uiManager.S_XOffset = AddSlider(AimConfig, "X Offset (Left/Right)", "Offset", 1, 1, -150, 150);
             uiManager.S_XOffset = AddSlider(AimConfig, "X Offset (%)", "Percent", 1, 1, 0, 100);
+
+            uiManager.S_EMASmoothing = AddSlider(AimConfig, "EMA Smoothening", "Amount", 0.01, 0.01, 0.01, 1);
 
             AddSeparator(AimConfig);
 
@@ -721,6 +729,14 @@ namespace Aimmy2
                 if (Dictionary.toggleState["Dynamic FOV"])
                 {
                     PropertyChanger.PostNewFOVSize(uiManager.S_DynamicFOVSize.Slider.Value);
+                }
+            };
+            uiManager.S_EMASmoothing.Slider.ValueChanged += (s, x) =>
+            {
+                if (Dictionary.toggleState["EMA Smoothening"])
+                {
+                    MouseManager.smoothingFactor = uiManager.S_EMASmoothing.Slider.Value;
+                    Debug.WriteLine(MouseManager.smoothingFactor);
                 }
             };
             AddSeparator(FOVConfig);

--- a/Aimmy2/MainWindow.xaml.cs
+++ b/Aimmy2/MainWindow.xaml.cs
@@ -768,7 +768,6 @@ namespace Aimmy2
             uiManager.S_DPBorderThickness.Slider.ValueChanged += (s, x) => PropertyChanger.PostDPWBorderThickness(uiManager.S_DPBorderThickness.Slider.Value);
 
             uiManager.S_DPOpacity = AddSlider(ESPConfig, "Opacity", "Opacity", 0.1, 0.1, 0, 1);
-            uiManager.S_DPOpacity.Slider.ValueChanged += (s, x) => PropertyChanger.PostDPWOpacity(uiManager.S_DPOpacity.Slider.Value);
 
             AddSeparator(ESPConfig);
 

--- a/Aimmy2/MainWindow.xaml.cs
+++ b/Aimmy2/MainWindow.xaml.cs
@@ -312,11 +312,7 @@ namespace Aimmy2
                     break;
 
                 case "Show AI Confidence":
-                    if (!Dictionary.toggleState[title])
-                    {
-                        DPWindow.DetectedPlayerConfidence.Margin = new Thickness(0, 0, 0, 0);
-                        DPWindow.DetectedPlayerConfidence.Width = 0;
-                    }
+                    DPWindow.DetectedPlayerConfidence.Visibility = Dictionary.toggleState[title] ? Visibility.Visible : Visibility.Collapsed;
                     break;
 
                 case "Mouse Background Effect":

--- a/Aimmy2/Other/KeybindNameManager.cs
+++ b/Aimmy2/Other/KeybindNameManager.cs
@@ -27,6 +27,7 @@ namespace Other
             { "LShiftKey", "Left Shift" },
 
             { "Oem4", "Left Bracket"},
+            { "OemOpenBrackets", "Left Bracket"},
             { "Oem6", "Right Bracket"},
             { "Oem1", ";"},
             { "Oem3", "`" },


### PR DESCRIPTION
Pretty simple EMA system, UI stuff is a bit complicated for me so change it how you wish.
### Bug Fix(es)
- Fix Show AI Confidence
When You turn on AI Confidence, then off then back on it disappears, this fixes it while making it simpler
- Tracers Bug Fix
When there's a detection with tracers on and you turn off tracers while its still detecting, the tracers will stay, this check if its false and if so to change the opacity of the tracers to 0
- ESP Opacity
Instead of changing the opacity straight when you change it, since the value is already stored in the dictionary when the UpdateOverlay Method is called we can instead update the opacity there, which then actually allows the feature to work as intended.
- Keybind Names
Changes "OemOpenBrackets" to "[", not quite sure if Oem4 is still used.