### PR TITLE
Fix Styling

### DIFF
--- a/Aimmy2/App.xaml
+++ b/Aimmy2/App.xaml
@@ -6,7 +6,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/AntWpf;component/Styles/Theme.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/AntWpf;component/Styles/Controls.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Dark.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Defaults.xaml" />
             </ResourceDictionary.MergedDictionaries>
 

--- a/Aimmy2/UISections/ModelMenuControl.xaml
+++ b/Aimmy2/UISections/ModelMenuControl.xaml
@@ -152,7 +152,8 @@
                                         FontFamily="{StaticResource Atkinson Hyperlegible}"
                                         Padding="5"
                                         Foreground="White"
-                                        TextChanged="SearchBox_TextChanged">
+                                        TextChanged="SearchBox_TextChanged"
+                                        CaretBrush="White">
                                     </TextBox>
                                 </Border>
                                 <StackPanel x:Name="ModelStoreScroller" />
@@ -193,7 +194,8 @@
                                         FontFamily="{StaticResource Atkinson Hyperlegible}"
                                         Padding="5"
                                         Foreground="White"
-                                        TextChanged="CSearchBox_TextChanged">
+                                        TextChanged="CSearchBox_TextChanged"
+                                        CaretBrush="White">
                                     </TextBox>
                                 </Border>
                                 <StackPanel x:Name="ConfigStoreScroller" />


### PR DESCRIPTION
Switch the MaterialDesignTheme to Dark mode instead of light, which fixes the tab headers have a black bottom border.
Manually change the caret brush to be white.

Before
![DOtdplGGcCTrd4ANo4k41390](https://github.com/user-attachments/assets/774fbb6b-2f58-48ac-a7e0-cf018ddb4418)
After
![fp5umK3DDYJl6YVKE8Tw1391](https://github.com/user-attachments/assets/2f5ef777-21a9-479e-96aa-059d2d80dbbe)
