### PR TITLE
Fix collect data & revert MaterialDesign Theme

### DIFF
--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -773,6 +773,7 @@ namespace Aimmy2.AILogic
 
             if (KDpoints.Count == 0 || KDPredictions.Count == 0)
             {
+                SaveFrame(frame);
                 return null;
             }
 

--- a/Aimmy2/Aimmy2.csproj
+++ b/Aimmy2/Aimmy2.csproj
@@ -70,11 +70,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.22.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.22.1" />
     <PackageReference Include="MouseKeyHook" Version="5.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Supercluster.KDTree" Version="1.0.4" />
-    <PackageReference Include="System.Management" Version="9.0.5" />
+    <PackageReference Include="System.Management" Version="9.0.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Vortice.Direct3D11" Version="3.6.2" />

--- a/Aimmy2/App.xaml
+++ b/Aimmy2/App.xaml
@@ -6,7 +6,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/AntWpf;component/Styles/Theme.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/AntWpf;component/Styles/Controls.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Dark.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Defaults.xaml" />
             </ResourceDictionary.MergedDictionaries>
 


### PR DESCRIPTION
Fix collect data while playing by calling `SaveFrame` when there is no KDpoints/KDPredictions.
Revert Material Design Theme back to light mode, dropdowns are light mode again, however the TabItem border brush styling is still black.

Bump dependencies:
`Microsoft.ML.OnnxRuntime.DirectML` to `1.22.1`
`System.Management` to `9.0.6`