### PR TITLE
Selectable Classes & Bug Fixes

### DIFF
--- a/Aimmy2/Class/Dictionary.cs
+++ b/Aimmy2/Class/Dictionary.cs
@@ -100,7 +100,8 @@ namespace Aimmy2.Class
             { "Screen Capture Method", "DirectX" },
             { "Tracer Position", "Bottom" },
             { "Movement Path", "Cubic Bezier" },
-            { "Image Size", "640" }
+            { "Image Size", "640" },
+            { "Target Class", "Best Confidence" }
         };
 
         public static Dictionary<string, dynamic> colorState = new()

--- a/Aimmy2/Class/UI.cs
+++ b/Aimmy2/Class/UI.cs
@@ -28,6 +28,7 @@ namespace Class
         public ADropdown? D_DetectionAreaType { get; set; }
         public ComboBoxItem? DDI_ClosestToCenterScreen { get; set; }
         public ADropdown? D_AimingBoundariesAlignment { get; set; }
+        public ADropdown? D_TargetClass { get; set; }
         public ASlider? S_MouseSensitivity { get; set; }
         public ASlider? S_MouseJitter { get; set; }
         public ASlider? S_StickyAimThreshold { get; set; }

--- a/Aimmy2/MainWindow.xaml.cs
+++ b/Aimmy2/MainWindow.xaml.cs
@@ -1027,6 +1027,11 @@ namespace Aimmy2
                     ["Bottom"] = 0,
                     ["Middle"] = 1,
                     ["Top"] = 2,
+                }),
+
+                ("Target Class", uiManager.D_TargetClass, new Dictionary<string, int>
+                {
+                    ["Best Confidence"] = 0,
                 })
             };
 


### PR DESCRIPTION
# Feature
You can now select which class to it will select during predictions, but you can still have it select the class with the best confidence.

# Bug Fixes
- Not Loading Classes on dynamic models
- Not comparing the prediction's confidence against the minimum confidence