### PR TITLE
Dynamic Maximum Fov Size & Bug Fixes

### DIFF
--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -35,7 +35,7 @@ namespace Aimmy2.AILogic
         }
 
         // Dynamic properties instead of constants
-        private int IMAGE_SIZE => _currentImageSize;
+        public int IMAGE_SIZE => _currentImageSize;
         private int NUM_DETECTIONS { get; set; } = 8400; // Will be set dynamically for dynamic models
         private bool IsDynamicModel { get; set; } = false;
         private int ModelFixedSize { get; set; } = 640; // Store the fixed size for non-dynamic models
@@ -46,6 +46,7 @@ namespace Aimmy2.AILogic
         };
         public Dictionary<int, string> ModelClasses => _modelClasses; // apparently this is better than making _modelClasses public
         public static event Action<Dictionary<int, string>>? ClassesUpdated;
+        public static event Action<int>? ImageSizeUpdated;
 
         private const int SAVE_FRAME_COOLDOWN_MS = 500;
 
@@ -347,6 +348,7 @@ namespace Aimmy2.AILogic
                     // For dynamic models, calculate NUM_DETECTIONS based on selected image size
                     NUM_DETECTIONS = CalculateNumDetections(IMAGE_SIZE);
                     LoadClasses();
+                    ImageSizeUpdated?.Invoke(IMAGE_SIZE);
                     LogManager.Log(LogLevel.Info, $"Loaded dynamic model - using selected image size {IMAGE_SIZE}x{IMAGE_SIZE} with {NUM_DETECTIONS} detections", true, 3000);
                 }
                 else
@@ -384,6 +386,7 @@ namespace Aimmy2.AILogic
 
                         // The IMAGE_SIZE property will now return the correct value
                         NUM_DETECTIONS = CalculateNumDetections(fixedInputSize);
+                        ImageSizeUpdated?.Invoke(fixedInputSize);
                     }
                     else if (!supportedSizes.Contains(fixedSizeStr))
                     {

--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -625,8 +625,8 @@ namespace Aimmy2.AILogic
 
                 await Application.Current.Dispatcher.BeginInvoke(() =>
                     Dictionary.FOVWindow.FOVStrictEnclosure.Margin = new Thickness(
-                        Convert.ToInt16(displayRelativeX / WinAPICaller.scalingFactorX) - (IMAGE_SIZE / 2),
-                        Convert.ToInt16(displayRelativeY / WinAPICaller.scalingFactorY) - (IMAGE_SIZE / 2), 0, 0));
+                        Convert.ToInt16(displayRelativeX / WinAPICaller.scalingFactorX) - 320, // this is based off the window size, not the size of the model -whip
+                        Convert.ToInt16(displayRelativeY / WinAPICaller.scalingFactorY) - 320, 0, 0));
             }
         }
 

--- a/Aimmy2/AILogic/CaptureManager.cs
+++ b/Aimmy2/AILogic/CaptureManager.cs
@@ -393,6 +393,27 @@ namespace AILogic
                                 _lastSrcStride = srcStride;
                                 _lastDstStride = dstStride;
                             }
+
+                            if (Dictionary.toggleState["Third Person Support"])
+                            {
+                                int width = w / 2;
+                                int height = h / 2;
+                                int startY = h - height;
+
+                                byte* dstPtr = (byte*)mapDest.Scan0;
+                                for (int y = startY; y < h; y++)
+                                {
+                                    byte* rowPtr = dstPtr + (y * dstStride);
+                                    for (int x = 0; x < width; x++)
+                                    {
+                                        int pixelOffset = x * 4;
+                                        rowPtr[pixelOffset] = 0; // R
+                                        rowPtr[pixelOffset + 1] = 0; // G
+                                        rowPtr[pixelOffset + 2] = 0; // B
+                                        rowPtr[pixelOffset + 3] = 255; // A
+                                    }
+                                }
+                            }
                         }
 
                         UpdateCache(currentBitmap, detectionBox);
@@ -484,7 +505,22 @@ namespace AILogic
                         detectionBox.Size,
                         CopyPixelOperation.SourceCopy
                     );
+
+                    if (Dictionary.toggleState["Third Person Support"])
+                    {
+                        int width = screenCaptureBitmap.Width / 2;
+                        int height = screenCaptureBitmap.Height / 2;
+                        int startY = screenCaptureBitmap.Height - height;
+
+                        using (var brush = new SolidBrush(System.Drawing.Color.Black))
+                        {
+                            g.FillRectangle(brush, 0, startY, width, height);
+                        }
+                    }
                 }
+
+
+
                 return screenCaptureBitmap;
             }
             catch (Exception ex)

--- a/Aimmy2/Class/Dictionary.cs
+++ b/Aimmy2/Class/Dictionary.cs
@@ -58,6 +58,7 @@ namespace Aimmy2.Class
             { "Anti Recoil", false },
             { "FOV", false },
             { "Dynamic FOV", false },
+            { "Third Person Support", false },
             { "Masking", false },
             { "Show Detected Player", false },
             { "Cursor Check", false },

--- a/Aimmy2/Class/UI.cs
+++ b/Aimmy2/Class/UI.cs
@@ -76,13 +76,13 @@ namespace Class
 
         // FOV
         public ATitle? AT_FOV { get; set; }
+        public AToggle? T_FOV { get; set; }
+        public AToggle? T_DynamicFOV { get; set; }
+        public AToggle? T_ThirdPersonSupport { get; set; }
+        public AKeyChanger? C_DynamicFOV { get; set; }
         //--
         public ADropdown D_FOVSTYLE { get; set; }
         //--
-        public AToggle? T_FOV { get; set; }
-
-        public AToggle? T_DynamicFOV { get; set; }
-        public AKeyChanger? C_DynamicFOV { get; set; }
         public AColorChanger? CC_FOVColor { get; set; }
         public ASlider? S_FOVSize { get; set; }
         public ASlider? S_DynamicFOVSize { get; set; }

--- a/Aimmy2/UISections/AboutMenuControl.xaml.cs
+++ b/Aimmy2/UISections/AboutMenuControl.xaml.cs
@@ -26,6 +26,7 @@ namespace Aimmy2.Controls
                 ("whoswhip", "Bug fixes & EMA"),
                 ("HakaCat", "Idea for Auto Labelling Data"),
                 ("Themida", "LGHub check"),
+                ("camilia2o7", "Stream Guard & Bug Fixes"), 
                 ("Ninja", "MarsQQ's emotional support")
             }),
             ("Model Creators", new[]

--- a/Aimmy2/UISections/AimMenuControl.xaml.cs
+++ b/Aimmy2/UISections/AimMenuControl.xaml.cs
@@ -419,6 +419,7 @@ namespace Aimmy2.Controls
                 })
                 .AddToggle("FOV", t => uiManager.T_FOV = t)
                 .AddToggle("Dynamic FOV", t => uiManager.T_DynamicFOV = t)
+                .AddToggle("Third Person Support", t => uiManager.T_ThirdPersonSupport = t)
                 .AddKeyChanger("Dynamic FOV Keybind", k => uiManager.C_DynamicFOV = k)
                 .AddDropdown("FOV Style", d =>
                 {

--- a/Aimmy2/UISections/AimMenuControl.xaml.cs
+++ b/Aimmy2/UISections/AimMenuControl.xaml.cs
@@ -61,6 +61,7 @@ namespace Aimmy2.Controls
             LoadMinimizeStatesFromGlobal();
 
             AIManager.ClassesUpdated += OnClassesChanged;
+            AIManager.ImageSizeUpdated += OnImageSizeChanged;
 
             // Load all sections
             LoadAimAssist();
@@ -637,6 +638,27 @@ namespace Aimmy2.Controls
             }
 
             dropdown.DropdownBox.SelectedIndex = 0;
+        }
+
+        private void OnImageSizeChanged(int imageSize)
+        {
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                if (_mainWindow?.uiManager.S_FOVSize != null && _mainWindow?.uiManager.S_DynamicFOVSize != null)
+                {
+                    UpdateFovSizeSlider(_mainWindow.uiManager.S_FOVSize, imageSize);
+                    UpdateFovSizeSlider(_mainWindow.uiManager.S_DynamicFOVSize, imageSize);
+                }
+            });
+        }
+        private void UpdateFovSizeSlider(ASlider slider, int imageSize = 640)
+        {
+            if (slider.Slider == null) return;
+            if (imageSize < slider.Slider.Value)
+            {
+                slider.Slider.Value = imageSize;
+            }
+            slider.Slider.Maximum = imageSize;
         }
 
         private void HandleColorChange(AColorChanger colorChanger, string settingKey, Action<Color> updateAction)

--- a/Aimmy2/UISections/ModelMenuControl.xaml
+++ b/Aimmy2/UISections/ModelMenuControl.xaml
@@ -46,7 +46,6 @@
                         <Border Background="#3F3C3C3C"
                                 BorderBrush="#3FFFFFFF"
                                 BorderThickness="1"
-                                CornerRadius="5,5,0,0"
                                 Margin="0,55,0,54">
                             <ListBox x:Name="ModelListBox"
                                      AllowDrop="True"
@@ -126,7 +125,6 @@
                         <Border Background="#3F3C3C3C"
                                 BorderBrush="#3FFFFFFF"
                                 BorderThickness="1"
-                                CornerRadius="5,5,0,0"
                                 Margin="0,55,0,54">
                             <ListBox x:Name="ConfigsListBox"
                                      AllowDrop="True"


### PR DESCRIPTION
# Features
- When changing image size or loading a smaller size model, both the fov slider's maximum value will be changed to the image size.

- Third person support, this is done by blocking out 1/4 of the bitmap in the bottom left

# Bug Fixes
- Fov not being centered when using an image size smaller than 640x640
- Remove corner radius from the model menu local stores, since there is now a rounded search bar above it

# General
- Added camilia2o7 to credits/contributors for Stream Guard and Bug Fixes