### PR TITLE
Bug Fixes - Anti Recoil & Cursor Check

### DIFF
--- a/Aimmy2/InputLogic/MouseManager.cs
+++ b/Aimmy2/InputLogic/MouseManager.cs
@@ -260,12 +260,7 @@ namespace InputLogic
             previousX = newPosition.X;
             previousY = newPosition.Y;
 
-            if (Dictionary.toggleState["Auto Trigger"] &&
-                !Dictionary.toggleState["Spray Mode"])
-            {
-                Task.Run(() => DoTriggerClick());
-            }
-            else if (!Dictionary.toggleState["Auto Trigger"])
+            if (!Dictionary.toggleState["Auto Trigger"])
             {
                 ResetSprayState();
             }

--- a/Aimmy2/MainWindow.xaml.cs
+++ b/Aimmy2/MainWindow.xaml.cs
@@ -216,8 +216,6 @@ namespace Aimmy2
             // Run non-UI operations in background
             await Task.Run(() =>
             {
-                arManager.HoldDownLoad();
-
                 // Load configurations that don't create UI
                 var configs = new[]
                 {
@@ -238,6 +236,7 @@ namespace Aimmy2
             LoadConfig();
             LoadAntiRecoilConfig();
 
+            arManager.HoldDownLoad(); // needs to be ran on ui thread or just cant be run via Task.Run -whip
             ApplyThemeColorFromConfig();
         }
 


### PR DESCRIPTION
## Bug Fixes
Anti Recoil is fixed by moving where `arManager.HoldDownLoad();` is called.

Cursor Check is fixed by removing the trigger click in MoveCrosshair