### PR TITLE
fix: only show target class dropdown when there are more than one classes

### DIFF
--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -423,7 +423,7 @@ namespace Aimmy2.AILogic
             {
                 var metadata = _onnxModel.ModelMetadata;
 
-                if (metadata != null && 
+                if (metadata != null &&
                     metadata.CustomMetadataMap.TryGetValue("names", out string? value) &&
                     !string.IsNullOrEmpty(value))
                 {
@@ -952,7 +952,7 @@ namespace Aimmy2.AILogic
                     outputTensor = results[0].AsTensor<float>();
                 }
 
-                if(outputTensor == null)
+                if (outputTensor == null)
                 {
                     Log(LogLevel.Error, "Model inference returned null output tensor.", true, 2000);
                     SaveFrame(frame);

--- a/Aimmy2/AILogic/MathUtil.cs
+++ b/Aimmy2/AILogic/MathUtil.cs
@@ -1,6 +1,4 @@
 ﻿using Aimmy2.AILogic;
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.CompilerServices;

--- a/Aimmy2/AILogic/PredictionManager.cs
+++ b/Aimmy2/AILogic/PredictionManager.cs
@@ -1,6 +1,4 @@
 ﻿using Aimmy2.Class;
-using Class;
-using System.Runtime.CompilerServices;
 
 namespace AILogic
 {

--- a/Aimmy2/Class/Animator.cs
+++ b/Aimmy2/Class/Animator.cs
@@ -1,6 +1,5 @@
 ﻿using System.Windows;
 using System.Windows.Media.Animation;
-using System.Windows.Shapes;
 
 namespace AimmyWPF.Class
 {

--- a/Aimmy2/Other/DisplayManager.cs
+++ b/Aimmy2/Other/DisplayManager.cs
@@ -83,7 +83,8 @@ namespace Aimmy2.Class
         private static void OnDisplaySettingsChanged(object? sender, EventArgs e)
         {
             // Add delay to ensure system has updated display info
-            Task.Delay(1000).ContinueWith(t => {
+            Task.Delay(1000).ContinueWith(t =>
+            {
                 ForceRefresh();
             });
         }

--- a/Aimmy2/Other/FileManager.cs
+++ b/Aimmy2/Other/FileManager.cs
@@ -38,7 +38,7 @@ namespace Other
             ConfigListBox.SelectionChanged += ConfigListBox_SelectionChanged;
 
             ModelListBox.AllowDrop = true;
-            ModelListBox.DragOver += ModelListBox_DragOver; 
+            ModelListBox.DragOver += ModelListBox_DragOver;
             ModelListBox.Drop += ModelListBox_DragDrop;
 
             ConfigListBox.AllowDrop = true;

--- a/Aimmy2/Other/GetSpecs.cs
+++ b/Aimmy2/Other/GetSpecs.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Management;
-using Vortice.DXGI;
+﻿using System.Management;
 using Visuality;
+using Vortice.DXGI;
 
 namespace Aimmy2.Class
 {

--- a/Aimmy2/Other/LogManager.cs
+++ b/Aimmy2/Other/LogManager.cs
@@ -19,15 +19,15 @@ namespace Other
         {
             if (notifyUser)
             {
-               Application.Current.Dispatcher.Invoke(() =>
-               {
-                   new NoticeBar(message, waitingTime).Show();
-               });
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    new NoticeBar(message, waitingTime).Show();
+                });
             }
 #if DEBUG
             Debug.WriteLine(message);
 #endif
-            if(Dictionary.toggleState["Debug Mode"])
+            if (Dictionary.toggleState["Debug Mode"])
             {
                 string logFilepath = "debug.txt";
                 using StreamWriter w = new(logFilepath, true);

--- a/Aimmy2/Other/StreamGuardManager.cs
+++ b/Aimmy2/Other/StreamGuardManager.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using System.Windows;
-using System.Windows.Interop;
-using System.ComponentModel;
 using System.Windows.Controls;
+using System.Windows.Interop;
 using System.Windows.Media;
 
 namespace Aimmy2.Other
@@ -141,7 +138,8 @@ namespace Aimmy2.Other
             }
             else if (enable)
             {
-                userControl.Loaded += (s, e) => {
+                userControl.Loaded += (s, e) =>
+                {
                     Window delayedWindow = FindParentWindow(userControl);
                     if (delayedWindow != null)
                     {

--- a/Aimmy2/UILibrary/AColorWheel.xaml.cs
+++ b/Aimmy2/UILibrary/AColorWheel.xaml.cs
@@ -1,6 +1,4 @@
 ﻿using Aimmy2.Theme;
-using Newtonsoft.Json.Linq;
-using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows;
@@ -11,7 +9,6 @@ using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Visuality;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.ScrollBar;
 
 namespace Aimmy2.UILibrary
 {

--- a/Aimmy2/UILibrary/AToggle.xaml.cs
+++ b/Aimmy2/UILibrary/AToggle.xaml.cs
@@ -1,8 +1,8 @@
-﻿using AimmyWPF.Class;
+﻿using Aimmy2.Theme;
+using AimmyWPF.Class;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
-using Aimmy2.Theme;
 
 namespace Aimmy2.UILibrary
 {

--- a/Aimmy2/UISections/AboutMenuControl.xaml.cs
+++ b/Aimmy2/UISections/AboutMenuControl.xaml.cs
@@ -1,3 +1,5 @@
+using Aimmy2.Theme;
+using Other;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Windows;
@@ -6,8 +8,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using Aimmy2.Theme;
-using Other;
 
 namespace Aimmy2.Controls
 {

--- a/Aimmy2/UISections/ModelMenuControl.xaml.cs
+++ b/Aimmy2/UISections/ModelMenuControl.xaml.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Aimmy2.UILibrary;
+using Other;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
-using Aimmy2.Class;
-using Aimmy2.UILibrary;
-using Other;
 using Visuality;
-using System.Security.Cryptography;
 
 namespace Aimmy2.Controls
 {

--- a/Aimmy2/UISections/SettingsMenuControl.xaml.cs
+++ b/Aimmy2/UISections/SettingsMenuControl.xaml.cs
@@ -68,6 +68,7 @@ namespace Aimmy2.Controls
 
             // Set visibility based on current model status (handles case where model loaded before panel opened)
             UpdateDynamicModelDropdownsVisibility(AIManager.CurrentModelIsDynamic);
+            UpdateTargetClassDropdown(_mainWindow!.uiManager.D_TargetClass!);
         }
 
         #region Minimize State Management
@@ -439,6 +440,12 @@ namespace Aimmy2.Controls
         private void UpdateTargetClassDropdown(ADropdown dropdown, Dictionary<int, string>? _classes = null)
         {
             if (dropdown?.DropdownBox == null) return;
+            var visibility = _classes != null && _classes.Count > 1
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+            dropdown.Visibility = visibility;
+            _mainWindow!.uiManager.D_TargetClass!.Visibility = visibility;
+
             string? selection = (dropdown.DropdownBox.SelectedItem as ComboBoxItem)?.Content?.ToString();
 
             var removedItems = dropdown.DropdownBox.Items.Cast<ComboBoxItem>()

--- a/Aimmy2/UISections/SettingsMenuControl.xaml.cs
+++ b/Aimmy2/UISections/SettingsMenuControl.xaml.cs
@@ -1,9 +1,6 @@
 ﻿using Aimmy2.AILogic;
 using Aimmy2.Class;
-using Aimmy2.MouseMovementLibraries.GHubSupport;
 using Aimmy2.UILibrary;
-using MouseMovementLibraries.ddxoftSupport;
-using MouseMovementLibraries.RazerSupport;
 using Other;
 using System.Windows;
 using System.Windows.Controls;

--- a/Aimmy2/Visuality/ColorPicker.xaml.cs
+++ b/Aimmy2/Visuality/ColorPicker.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using Aimmy2.Theme;
-using System;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;

--- a/Aimmy2/Visuality/FOV.xaml.cs
+++ b/Aimmy2/Visuality/FOV.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using Aimmy2.Class;
 using Aimmy2.Theme;
-using Aimmy2.UILibrary;
 using Class;
 using System.Runtime.InteropServices;
 using System.Windows;


### PR DESCRIPTION
fix: only show target class dropdown when there are more than one classes
chore: code cleanup + format
this is done via visual studio's default code clean up profile, it sorts usings and removes unused usings