### PR TITLE
refactor: isolate aim processing logic

### DIFF
--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -77,21 +77,6 @@ namespace Aimmy2.AILogic
         // For Auto-Labelling Data System
         private bool PlayerFound = false;
 
-        // Sticky-Aim
-        private Prediction? _currentTarget = null;
-        private int _consecutiveFramesWithoutTarget = 0;
-        private const int MAX_FRAMES_WITHOUT_TARGET = 3; // Allow 3 frames of target loss
-
-        // Enhanced Sticky Aim State
-        private float _lastTargetVelocityX = 0f;
-        private float _lastTargetVelocityY = 0f;
-        private float _targetLockScore = 0f;           // Accumulated "stickiness" score
-        private const float LOCK_SCORE_DECAY = 0.85f;  // Decay per frame when target not matched
-        private const float LOCK_SCORE_GAIN = 15f;     // Gain per frame when target matched
-        private const float MAX_LOCK_SCORE = 100f;     // Maximum accumulated score
-        private const float REFERENCE_TARGET_SIZE = 10000f; // Reference area for "close" targets (approx 100x100)
-        private int _framesWithoutMatch = 0;           // Consecutive frames where current target wasn't found
-
         private double CenterXTranslated = 0;
         private double CenterYTranslated = 0;
 
@@ -120,6 +105,7 @@ namespace Aimmy2.AILogic
 
 
         private readonly CaptureManager _captureManager = new();
+        private readonly StickyAimSelector _stickyAimSelector = new();
         #endregion Variables
 
         #region Benchmarking
@@ -466,16 +452,18 @@ namespace Aimmy2.AILogic
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ShouldPredict() =>
-            Dictionary.toggleState["Show Detected Player"] ||
-            Dictionary.toggleState["Constant AI Tracking"] ||
-            InputBindingManager.IsHoldingBinding("Aim Keybind") ||
-            InputBindingManager.IsHoldingBinding("Second Aim Keybind");
+            AimProcessingDecisions.ShouldRunPrediction(
+                Dictionary.toggleState["Show Detected Player"],
+                Dictionary.toggleState["Constant AI Tracking"],
+                InputBindingManager.IsHoldingBinding("Aim Keybind"),
+                InputBindingManager.IsHoldingBinding("Second Aim Keybind"));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ShouldProcess() =>
-            Dictionary.toggleState["Aim Assist"] ||
-            Dictionary.toggleState["Show Detected Player"] ||
-            Dictionary.toggleState["Auto Trigger"];
+            AimProcessingDecisions.ShouldProcessFrame(
+                Dictionary.toggleState["Aim Assist"],
+                Dictionary.toggleState["Show Detected Player"],
+                Dictionary.toggleState["Auto Trigger"]);
 
         private async void AiLoop()
         {
@@ -563,10 +551,11 @@ namespace Aimmy2.AILogic
             // or if the aim keybinds are not held,
             // or if constant AI tracking is enabled,
             // we check for spray release and return
-            if (!Dictionary.toggleState["Auto Trigger"] ||
-                !(InputBindingManager.IsHoldingBinding("Aim Keybind") && !InputBindingManager.IsHoldingBinding("Second Aim Keybind")) ||
-                Dictionary.toggleState["Constant AI Tracking"]) // this logic is a bit weird, but it works.
-                                                                // but it might need to be revised
+            if (!AimProcessingDecisions.ShouldAttemptAutoTrigger(
+                Dictionary.toggleState["Auto Trigger"],
+                InputBindingManager.IsHoldingBinding("Aim Keybind"),
+                InputBindingManager.IsHoldingBinding("Second Aim Keybind"),
+                Dictionary.toggleState["Constant AI Tracking"]))
             {
                 CheckSprayRelease();
                 return;
@@ -608,12 +597,10 @@ namespace Aimmy2.AILogic
 
             // if auto trigger is disabled, we reset the spray state
             // if the aim keybinds are not held, we reset the spray state
-            bool shouldSpray = Dictionary.toggleState["Auto Trigger"] &&
-                (InputBindingManager.IsHoldingBinding("Aim Keybind") && InputBindingManager.IsHoldingBinding("Second Aim Keybind")); //||
-                                                                                                                                     //Dictionary.toggleState["Constant AI Tracking"];
-
-            // spray mode might need to be revised - taylor
-            if (!shouldSpray)
+            if (!AimProcessingDecisions.ShouldKeepSprayActive(
+                Dictionary.toggleState["Auto Trigger"],
+                InputBindingManager.IsHoldingBinding("Aim Keybind"),
+                InputBindingManager.IsHoldingBinding("Second Aim Keybind")))
             {
                 MouseManager.ResetSprayState();
             }
@@ -1001,7 +988,12 @@ namespace Aimmy2.AILogic
                     }
                 }
 
-                Prediction? finalTarget = HandleStickyAim(bestCandidate, KDPredictions);
+                Prediction? finalTarget = _stickyAimSelector.SelectTarget(
+                    Dictionary.toggleState["Sticky Aim"],
+                    (float)Dictionary.sliderSettings["Sticky Aim Threshold"],
+                    IMAGE_SIZE,
+                    bestCandidate,
+                    KDPredictions);
                 if (finalTarget != null)
                 {
                     UpdateDetectionBox(finalTarget, detectionBox);
@@ -1017,187 +1009,6 @@ namespace Aimmy2.AILogic
                 frame.Dispose();
                 results?.Dispose();
             }
-        }
-
-        private Prediction? HandleStickyAim(Prediction? bestCandidate, List<Prediction> KDPredictions)
-        {
-            if (!Dictionary.toggleState["Sticky Aim"])
-            {
-                _currentTarget = bestCandidate;
-                ResetStickyAimState();
-                return bestCandidate;
-            }
-
-            // No detections available
-            if (bestCandidate == null || KDPredictions == null || KDPredictions.Count == 0)
-            {
-                return HandleNoDetections();
-            }
-
-            _consecutiveFramesWithoutTarget = 0;
-
-            // Screen center (where user is aiming)
-            float screenCenterX = IMAGE_SIZE / 2f;
-            float screenCenterY = IMAGE_SIZE / 2f;
-
-            // STEP 1: Find what the user is aiming at (closest to crosshair)
-            Prediction? aimTarget = null;
-            float nearestToCrosshairDistSq = float.MaxValue;
-
-            foreach (var candidate in KDPredictions)
-            {
-                float distSq = GetDistanceSq(candidate.ScreenCenterX, candidate.ScreenCenterY, screenCenterX, screenCenterY);
-                if (distSq < nearestToCrosshairDistSq)
-                {
-                    nearestToCrosshairDistSq = distSq;
-                    aimTarget = candidate;
-                }
-            }
-
-            if (aimTarget == null)
-            {
-                return HandleNoDetections();
-            }
-
-            // No current target - acquire what user is aiming at
-            if (_currentTarget == null)
-            {
-                return AcquireNewTarget(aimTarget);
-            }
-
-            // STEP 2: Is the aim target the SAME as our current target?
-            float lastX = _currentTarget.ScreenCenterX;
-            float lastY = _currentTarget.ScreenCenterY;
-            float targetArea = _currentTarget.Rectangle.Width * _currentTarget.Rectangle.Height;
-            float targetSize = MathF.Sqrt(targetArea);
-            float sizeFactor = GetSizeFactor(targetArea);
-
-            // Distance from aim target to our current target's last position
-            float aimToCurrentDistSq = GetDistanceSq(aimTarget.ScreenCenterX, aimTarget.ScreenCenterY, lastX, lastY);
-
-            // Tracking radius based on target size - larger targets have larger radius
-            float trackingRadius = targetSize * 3f;
-            float trackingRadiusSq = trackingRadius * trackingRadius;
-
-            // Check size similarity
-            float aimTargetArea = aimTarget.Rectangle.Width * aimTarget.Rectangle.Height;
-            float sizeRatio = MathF.Min(targetArea, aimTargetArea) / MathF.Max(targetArea, aimTargetArea);
-
-            // Is the aim target the same as our current target?
-            // Same if: close to last position AND similar size
-            bool isSameTarget = (aimToCurrentDistSq < trackingRadiusSq) && (sizeRatio > 0.5f);
-
-            if (isSameTarget)
-            {
-                // User is still aiming at current target - update and continue
-                _framesWithoutMatch = 0;
-                UpdateVelocity(aimTarget, sizeFactor);
-                _targetLockScore = Math.Min(MAX_LOCK_SCORE, _targetLockScore + LOCK_SCORE_GAIN);
-                _currentTarget = aimTarget;
-                return aimTarget;
-            }
-
-            // STEP 3: User is aiming at a DIFFERENT target
-            // But we need hysteresis - don't switch on single-frame jitter
-            _framesWithoutMatch++;
-
-            // Quick switch if aim target is very close to crosshair (user clearly aiming at it)
-            float stickyThreshold = (float)Dictionary.sliderSettings["Sticky Aim Threshold"];
-            bool aimTargetVeryCentered = nearestToCrosshairDistSq < (stickyThreshold * stickyThreshold * 0.25f);
-
-            if (aimTargetVeryCentered || _framesWithoutMatch >= 3)
-            {
-                // User has clearly moved to new target - switch
-                return AcquireNewTarget(aimTarget);
-            }
-
-            // Not ready to switch yet - return null to avoid flicking
-            // (Don't return old target position, don't return new target position)
-            return null;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static float GetDistanceSq(float x1, float y1, float x2, float y2)
-        {
-            float dx = x1 - x2;
-            float dy = y1 - y2;
-            return dx * dx + dy * dy;
-        }
-
-        /// <summary>
-        /// Returns a scaling factor based on target size. Smaller targets (further away) get higher factors
-        /// to make thresholds more forgiving and filtering more aggressive.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private float GetSizeFactor(float targetArea)
-        {
-            // sizeFactor: 1.0 for large/close targets, up to 3.0 for small/distant targets
-            // This makes distant targets more "sticky" to compensate for detection jitter
-            float ratio = REFERENCE_TARGET_SIZE / Math.Max(targetArea, 100f);
-            return Math.Clamp(ratio, 1.0f, 3.0f);
-        }
-
-        private Prediction? HandleNoDetections()
-        {
-            if (_currentTarget != null && ++_consecutiveFramesWithoutTarget <= MAX_FRAMES_WITHOUT_TARGET)
-            {
-                // Decay lock score during grace period
-                _targetLockScore *= LOCK_SCORE_DECAY;
-
-                // Return predicted position instead of stale position
-                var predicted = new Prediction
-                {
-                    ScreenCenterX = _currentTarget.ScreenCenterX + _lastTargetVelocityX * _consecutiveFramesWithoutTarget,
-                    ScreenCenterY = _currentTarget.ScreenCenterY + _lastTargetVelocityY * _consecutiveFramesWithoutTarget,
-                    Rectangle = _currentTarget.Rectangle,
-                    Confidence = _currentTarget.Confidence * (1f - _consecutiveFramesWithoutTarget * 0.2f),
-                    ClassId = _currentTarget.ClassId,
-                    ClassName = _currentTarget.ClassName,
-                    CenterXTranslated = _currentTarget.CenterXTranslated,
-                    CenterYTranslated = _currentTarget.CenterYTranslated
-                };
-                return predicted;
-            }
-
-            ResetStickyAimState();
-            return null;
-        }
-
-        private Prediction AcquireNewTarget(Prediction target)
-        {
-            _lastTargetVelocityX = 0f;
-            _lastTargetVelocityY = 0f;
-            _targetLockScore = LOCK_SCORE_GAIN; // Start with some lock score
-            _framesWithoutMatch = 0;
-            _currentTarget = target;
-            return target;
-        }
-
-        private void UpdateVelocity(Prediction newTarget, float sizeFactor)
-        {
-            if (_currentTarget != null)
-            {
-                // EMA smoothing on velocity to reduce noise
-                // Use heavier smoothing for smaller/distant targets (more weight on old velocity)
-                // sizeFactor 1.0 -> 0.7/0.3, sizeFactor 3.0 -> 0.9/0.1
-                float smoothing = Math.Clamp(0.6f + (sizeFactor * 0.1f), 0.7f, 0.9f);
-                float newWeight = 1f - smoothing;
-
-                float newVelX = newTarget.ScreenCenterX - _currentTarget.ScreenCenterX;
-                float newVelY = newTarget.ScreenCenterY - _currentTarget.ScreenCenterY;
-                _lastTargetVelocityX = _lastTargetVelocityX * smoothing + newVelX * newWeight;
-                _lastTargetVelocityY = _lastTargetVelocityY * smoothing + newVelY * newWeight;
-            }
-        }
-
-        private void ResetStickyAimState()
-        {
-            _currentTarget = null;
-            _consecutiveFramesWithoutTarget = 0;
-            _framesWithoutMatch = 0;
-            _lastTargetVelocityX = 0f;
-            _lastTargetVelocityY = 0f;
-            _targetLockScore = 0f;
         }
 
         private void UpdateDetectionBox(Prediction target, Rectangle detectionBox)
@@ -1380,16 +1191,5 @@ namespace Aimmy2.AILogic
             _modeloptions?.Dispose();
             _bitmapBuffer = null;
         }
-    }
-    public class Prediction
-    {
-        public RectangleF Rectangle { get; set; }
-        public float Confidence { get; set; }
-        public int ClassId { get; set; } = 0;
-        public string ClassName { get; set; } = "Enemy";
-        public float CenterXTranslated { get; set; }
-        public float CenterYTranslated { get; set; }
-        public float ScreenCenterX { get; set; }  // Absolute screen position
-        public float ScreenCenterY { get; set; }
     }
 }

--- a/Aimmy2/AILogic/AimProcessingDecisions.cs
+++ b/Aimmy2/AILogic/AimProcessingDecisions.cs
@@ -1,0 +1,41 @@
+namespace Aimmy2.AILogic
+{
+    internal static class AimProcessingDecisions
+    {
+        internal static bool ShouldRunPrediction(
+            bool showDetectedPlayer,
+            bool constantAiTracking,
+            bool aimKeyHeld,
+            bool secondAimKeyHeld) =>
+            showDetectedPlayer ||
+            constantAiTracking ||
+            aimKeyHeld ||
+            secondAimKeyHeld;
+
+        internal static bool ShouldProcessFrame(
+            bool aimAssist,
+            bool showDetectedPlayer,
+            bool autoTrigger) =>
+            aimAssist ||
+            showDetectedPlayer ||
+            autoTrigger;
+
+        internal static bool ShouldAttemptAutoTrigger(
+            bool autoTrigger,
+            bool aimKeyHeld,
+            bool secondAimKeyHeld,
+            bool constantAiTracking) =>
+            autoTrigger &&
+            aimKeyHeld &&
+            !secondAimKeyHeld &&
+            !constantAiTracking;
+
+        internal static bool ShouldKeepSprayActive(
+            bool autoTrigger,
+            bool aimKeyHeld,
+            bool secondAimKeyHeld) =>
+            autoTrigger &&
+            aimKeyHeld &&
+            secondAimKeyHeld;
+    }
+}

--- a/Aimmy2/AILogic/Prediction.cs
+++ b/Aimmy2/AILogic/Prediction.cs
@@ -1,0 +1,16 @@
+using System.Drawing;
+
+namespace Aimmy2.AILogic
+{
+    public class Prediction
+    {
+        public RectangleF Rectangle { get; set; }
+        public float Confidence { get; set; }
+        public int ClassId { get; set; } = 0;
+        public string ClassName { get; set; } = "Enemy";
+        public float CenterXTranslated { get; set; }
+        public float CenterYTranslated { get; set; }
+        public float ScreenCenterX { get; set; }
+        public float ScreenCenterY { get; set; }
+    }
+}

--- a/Aimmy2/AILogic/StickyAimSelector.cs
+++ b/Aimmy2/AILogic/StickyAimSelector.cs
@@ -1,0 +1,167 @@
+namespace Aimmy2.AILogic
+{
+    internal sealed class StickyAimSelector
+    {
+        private const int MaxFramesWithoutTarget = 3;
+        private const float LockScoreDecay = 0.85f;
+        private const float LockScoreGain = 15f;
+        private const float MaxLockScore = 100f;
+        private const float ReferenceTargetSize = 10000f;
+
+        private Prediction? _currentTarget;
+        private int _consecutiveFramesWithoutTarget;
+        private float _lastTargetVelocityX;
+        private float _lastTargetVelocityY;
+        private float _targetLockScore;
+        private int _framesWithoutMatch;
+
+        internal Prediction? SelectTarget(
+            bool stickyAimEnabled,
+            float stickyThreshold,
+            int imageSize,
+            Prediction? bestCandidate,
+            IReadOnlyList<Prediction> predictions)
+        {
+            if (!stickyAimEnabled)
+            {
+                Reset();
+                return bestCandidate;
+            }
+
+            if (bestCandidate == null || predictions.Count == 0)
+            {
+                return HandleNoDetections();
+            }
+
+            _consecutiveFramesWithoutTarget = 0;
+
+            float screenCenterX = imageSize / 2f;
+            float screenCenterY = imageSize / 2f;
+            Prediction? aimTarget = null;
+            float nearestToCrosshairDistSq = float.MaxValue;
+
+            foreach (var candidate in predictions)
+            {
+                float distSq = GetDistanceSq(candidate.ScreenCenterX, candidate.ScreenCenterY, screenCenterX, screenCenterY);
+                if (distSq < nearestToCrosshairDistSq)
+                {
+                    nearestToCrosshairDistSq = distSq;
+                    aimTarget = candidate;
+                }
+            }
+
+            if (aimTarget == null)
+            {
+                return HandleNoDetections();
+            }
+
+            if (_currentTarget == null)
+            {
+                return AcquireNewTarget(aimTarget);
+            }
+
+            float lastX = _currentTarget.ScreenCenterX;
+            float lastY = _currentTarget.ScreenCenterY;
+            float targetArea = _currentTarget.Rectangle.Width * _currentTarget.Rectangle.Height;
+            float targetSize = MathF.Sqrt(targetArea);
+            float sizeFactor = GetSizeFactor(targetArea);
+            float aimToCurrentDistSq = GetDistanceSq(aimTarget.ScreenCenterX, aimTarget.ScreenCenterY, lastX, lastY);
+            float trackingRadius = targetSize * 3f;
+            float trackingRadiusSq = trackingRadius * trackingRadius;
+            float aimTargetArea = aimTarget.Rectangle.Width * aimTarget.Rectangle.Height;
+            float sizeRatio = MathF.Min(targetArea, aimTargetArea) / MathF.Max(targetArea, aimTargetArea);
+            bool isSameTarget = aimToCurrentDistSq < trackingRadiusSq && sizeRatio > 0.5f;
+
+            if (isSameTarget)
+            {
+                _framesWithoutMatch = 0;
+                UpdateVelocity(aimTarget, sizeFactor);
+                _targetLockScore = Math.Min(MaxLockScore, _targetLockScore + LockScoreGain);
+                _currentTarget = aimTarget;
+                return aimTarget;
+            }
+
+            _framesWithoutMatch++;
+
+            bool aimTargetVeryCentered = nearestToCrosshairDistSq < stickyThreshold * stickyThreshold * 0.25f;
+            if (aimTargetVeryCentered || _framesWithoutMatch >= 3)
+            {
+                return AcquireNewTarget(aimTarget);
+            }
+
+            return null;
+        }
+
+        private static float GetDistanceSq(float x1, float y1, float x2, float y2)
+        {
+            float dx = x1 - x2;
+            float dy = y1 - y2;
+            return dx * dx + dy * dy;
+        }
+
+        private static float GetSizeFactor(float targetArea)
+        {
+            float ratio = ReferenceTargetSize / Math.Max(targetArea, 100f);
+            return Math.Clamp(ratio, 1.0f, 3.0f);
+        }
+
+        private Prediction? HandleNoDetections()
+        {
+            if (_currentTarget != null && ++_consecutiveFramesWithoutTarget <= MaxFramesWithoutTarget)
+            {
+                _targetLockScore *= LockScoreDecay;
+
+                return new Prediction
+                {
+                    ScreenCenterX = _currentTarget.ScreenCenterX + _lastTargetVelocityX * _consecutiveFramesWithoutTarget,
+                    ScreenCenterY = _currentTarget.ScreenCenterY + _lastTargetVelocityY * _consecutiveFramesWithoutTarget,
+                    Rectangle = _currentTarget.Rectangle,
+                    Confidence = _currentTarget.Confidence * (1f - _consecutiveFramesWithoutTarget * 0.2f),
+                    ClassId = _currentTarget.ClassId,
+                    ClassName = _currentTarget.ClassName,
+                    CenterXTranslated = _currentTarget.CenterXTranslated,
+                    CenterYTranslated = _currentTarget.CenterYTranslated
+                };
+            }
+
+            Reset();
+            return null;
+        }
+
+        private Prediction AcquireNewTarget(Prediction target)
+        {
+            _lastTargetVelocityX = 0f;
+            _lastTargetVelocityY = 0f;
+            _targetLockScore = LockScoreGain;
+            _framesWithoutMatch = 0;
+            _currentTarget = target;
+            return target;
+        }
+
+        private void UpdateVelocity(Prediction newTarget, float sizeFactor)
+        {
+            if (_currentTarget == null)
+            {
+                return;
+            }
+
+            float smoothing = Math.Clamp(0.6f + sizeFactor * 0.1f, 0.7f, 0.9f);
+            float newWeight = 1f - smoothing;
+
+            float newVelX = newTarget.ScreenCenterX - _currentTarget.ScreenCenterX;
+            float newVelY = newTarget.ScreenCenterY - _currentTarget.ScreenCenterY;
+            _lastTargetVelocityX = _lastTargetVelocityX * smoothing + newVelX * newWeight;
+            _lastTargetVelocityY = _lastTargetVelocityY * smoothing + newVelY * newWeight;
+        }
+
+        private void Reset()
+        {
+            _currentTarget = null;
+            _consecutiveFramesWithoutTarget = 0;
+            _framesWithoutMatch = 0;
+            _lastTargetVelocityX = 0f;
+            _lastTargetVelocityY = 0f;
+            _targetLockScore = 0f;
+        }
+    }
+}

--- a/Aimmy2/Other/FileManager.cs
+++ b/Aimmy2/Other/FileManager.cs
@@ -37,15 +37,6 @@ namespace Other
             ModelListBox.SelectionChanged += ModelListBox_SelectionChanged;
             ConfigListBox.SelectionChanged += ConfigListBox_SelectionChanged;
 
-            ModelListBox.AllowDrop = true;
-            ModelListBox.DragOver += ModelListBox_DragOver;
-            ModelListBox.Drop += ModelListBox_DragDrop;
-
-            ConfigListBox.AllowDrop = true;
-            ConfigListBox.DragOver += ConfigListBox_DragDrop;
-            ConfigListBox.Drop += ConfigListBox_DragDrop;
-
-
             CheckForRequiredFolders();
             InitializeFileWatchers();
             LoadModelsIntoListBox(null, null);
@@ -123,6 +114,7 @@ namespace Other
             string selectedConfig = ConfigListBox.SelectedItem.ToString()!;
 
             string configPath = Path.Combine("bin/configs", selectedConfig);
+            Dictionary.lastLoadedConfig = selectedConfig;
 
             SaveDictionary.LoadJSON(Dictionary.sliderSettings, configPath);
             PropertyChanger.PostNewConfig(configPath, true);
@@ -161,71 +153,6 @@ namespace Other
             }
         }
 
-        private void ModelListBox_DragOver(object sender, DragEventArgs e)
-        {
-            if (e.Data.GetDataPresent(DataFormats.FileDrop))
-            {
-                e.Effects = DragDropEffects.Copy;
-            }
-            else
-            {
-                e.Effects = DragDropEffects.None;
-            }
-
-            e.Handled = true;
-        }
-
-        private void ModelListBox_DragDrop(object sender, DragEventArgs e)
-        {
-            if (e.Data.GetDataPresent(DataFormats.FileDrop))
-            {
-                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-                string targetFolder = "bin/models";
-
-                foreach (var file in files)
-                {
-                    if (Path.GetExtension(file) == ".onnx")
-                    {
-                        string fileName = Path.GetFileName(file);
-                        string destFile = Path.Combine(targetFolder, fileName);
-                        File.Move(file, destFile, true);
-                    }
-                }
-            }
-        }
-        private void ConfigListBox_DragOver(object sender, DragEventArgs e)
-        {
-            if (e.Data.GetDataPresent(DataFormats.FileDrop))
-            {
-                e.Effects = DragDropEffects.Copy;
-            }
-            else
-            {
-                e.Effects = DragDropEffects.None;
-            }
-
-            e.Handled = true;
-        }
-
-        private void ConfigListBox_DragDrop(object sender, DragEventArgs e)
-        {
-            if (e.Data.GetDataPresent(DataFormats.FileDrop))
-            {
-                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-                string targetFolder = "bin/models";
-
-                foreach (var file in files)
-                {
-                    if (Path.GetExtension(file) == ".cfg")
-                    {
-                        string fileName = Path.GetFileName(file);
-                        string destFile = Path.Combine(targetFolder, fileName);
-                        File.Move(file, destFile, true);
-                    }
-                }
-            }
-        }
-
         public void LoadModelsIntoListBox(object? sender, FileSystemEventArgs? e)
         {
             if (!InQuittingState)
@@ -243,7 +170,7 @@ namespace Other
                     if (ModelListBox.Items.Count > 0)
                     {
                         string? lastLoadedModel = Dictionary.lastLoadedModel;
-                        if (lastLoadedModel != "N/A" && !ModelListBox.Items.Contains(lastLoadedModel)) { ModelListBox.SelectedItem = lastLoadedModel; }
+                        if (lastLoadedModel != "N/A" && ModelListBox.Items.Contains(lastLoadedModel)) { ModelListBox.SelectedItem = lastLoadedModel; }
                         SelectedModelNotifier.Content = $"Loaded Model: {lastLoadedModel}";
                     }
                 });
@@ -267,7 +194,7 @@ namespace Other
                     if (ConfigListBox.Items.Count > 0)
                     {
                         string? lastLoadedConfig = Dictionary.lastLoadedConfig;
-                        if (lastLoadedConfig != "N/A" && !ConfigListBox.Items.Contains(lastLoadedConfig)) { ConfigListBox.SelectedItem = lastLoadedConfig; }
+                        if (lastLoadedConfig != "N/A" && ConfigListBox.Items.Contains(lastLoadedConfig)) { ConfigListBox.SelectedItem = lastLoadedConfig; }
 
                         SelectedConfigNotifier.Content = "Loaded Config: " + lastLoadedConfig;
                     }


### PR DESCRIPTION
## Summary
- Extract aim-processing decisions, prediction data shape, and sticky aim selection out of AIManager.
- Keep runtime behavior wired through the existing AI loop and settings dictionaries.
- Keep model/config drag-and-drop owned by ModelMenuControl while retaining FileManager list reload/reselect behavior.

## Stack
1. This PR: refactor/aim-processing-logic -> Aimmy-V2
2. refactor/prediction-filter -> refactor/aim-processing-logic
3. refactor/model-session -> refactor/prediction-filter
4. refactor/capture-boundary -> refactor/model-session
5. refactor/settings-facade -> refactor/capture-boundary

## Verification
- `dotnet run --project .\.rework-tests\ReviewHarness\ReviewHarness.csproj`
- `powershell -ExecutionPolicy Bypass -File .\.rework-tests\ReviewCleanupChecks.ps1`
- `dotnet build .\Aimmy2\Aimmy2.csproj -v:minimal`
- `git diff --check`
- Runtime smoke confirmed model/config load, toggles, capture, and aim loop behavior on the full stack.