### PR TITLE
refactor: extract model session loading

### DIFF
--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -203,21 +203,22 @@ namespace Aimmy2.AILogic
 
             _modeloptions = new RunOptions();
 
-            var sessionOptions = OnnxModelSessionFactory.CreateDefaultOptions();
-
             // Attempt to load via DirectML (else fallback to CPU)
-            Task.Run(() => InitializeModel(sessionOptions, modelPath));
+            Task.Run(() => InitializeModel(modelPath));
         }
 
         #region Models
 
-        private async Task InitializeModel(SessionOptions sessionOptions, string modelPath)
+        private async Task InitializeModel(string modelPath)
         {
             using (Benchmark("ModelInitialization"))
             {
                 try
                 {
-                    await LoadModelAsync(sessionOptions, modelPath, useDirectML: true);
+                    if (!await LoadModelAsync(modelPath, useDirectML: true))
+                    {
+                        return;
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -225,41 +226,42 @@ namespace Aimmy2.AILogic
 
                     try
                     {
-                        await LoadModelAsync(sessionOptions, modelPath, useDirectML: false);
+                        await LoadModelAsync(modelPath, useDirectML: false);
                     }
                     catch (Exception e)
                     {
                         Log(LogLevel.Error, $"Error starting the model via CPU: {e.Message}, you won't be able to aim assist at all.", true);
                     }
                 }
-
-                FileManager.CurrentlyLoadingModel = false;
+                finally
+                {
+                    FileManager.CurrentlyLoadingModel = false;
+                }
             }
         }
 
-        private Task LoadModelAsync(SessionOptions sessionOptions, string modelPath, bool useDirectML)
+        private Task<bool> LoadModelAsync(string modelPath, bool useDirectML)
         {
             try
             {
-                OnnxModelLoadResult loadedModel = OnnxModelSessionFactory.Load(modelPath, sessionOptions, useDirectML);
+                OnnxModelLoadResult loadedModel = OnnxModelSessionFactory.Load(modelPath, useDirectML);
                 _onnxModel = loadedModel.Session;
                 _outputNames = loadedModel.OutputNames;
 
                 // Validate the onnx model output shape (ensure model is OnnxV8)
                 if (!ValidateOnnxShape())
                 {
-                    _onnxModel?.Dispose();
-                    return Task.CompletedTask;
+                    DisposeLoadedModel();
+                    return Task.FromResult(false);
                 }
 
                 // Pre-allocate bitmap buffer
                 _bitmapBuffer = new byte[3 * IMAGE_SIZE * IMAGE_SIZE];
             }
-            catch (Exception ex)
+            catch
             {
-                Log(LogLevel.Error, $"Error loading the model: {ex.Message}", true);
-                _onnxModel?.Dispose();
-                return Task.CompletedTask;
+                DisposeLoadedModel();
+                throw;
             }
 
             // Begin the loop
@@ -270,7 +272,14 @@ namespace Aimmy2.AILogic
                 Priority = ThreadPriority.AboveNormal // Higher priority for AI thread
             };
             _aiLoopThread.Start();
-            return Task.CompletedTask;
+            return Task.FromResult(true);
+        }
+
+        private void DisposeLoadedModel()
+        {
+            _onnxModel?.Dispose();
+            _onnxModel = null;
+            _outputNames = null;
         }
 
         private bool ValidateOnnxShape()

--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -203,15 +203,7 @@ namespace Aimmy2.AILogic
 
             _modeloptions = new RunOptions();
 
-            var sessionOptions = new SessionOptions
-            {
-                EnableCpuMemArena = true,
-                EnableMemoryPattern = false,
-                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
-                ExecutionMode = ExecutionMode.ORT_SEQUENTIAL,
-                InterOpNumThreads = 1,
-                IntraOpNumThreads = 4
-            };
+            var sessionOptions = OnnxModelSessionFactory.CreateDefaultOptions();
 
             // Attempt to load via DirectML (else fallback to CPU)
             Task.Run(() => InitializeModel(sessionOptions, modelPath));
@@ -249,11 +241,9 @@ namespace Aimmy2.AILogic
         {
             try
             {
-                if (useDirectML) { sessionOptions.AppendExecutionProvider_DML(); }
-                else { sessionOptions.AppendExecutionProvider_CPU(); }
-
-                _onnxModel = new InferenceSession(modelPath, sessionOptions);
-                _outputNames = new List<string>(_onnxModel.OutputMetadata.Keys);
+                OnnxModelLoadResult loadedModel = OnnxModelSessionFactory.Load(modelPath, sessionOptions, useDirectML);
+                _onnxModel = loadedModel.Session;
+                _outputNames = loadedModel.OutputNames;
 
                 // Validate the onnx model output shape (ensure model is OnnxV8)
                 if (!ValidateOnnxShape())

--- a/Aimmy2/AILogic/OnnxModelSessionFactory.cs
+++ b/Aimmy2/AILogic/OnnxModelSessionFactory.cs
@@ -17,13 +17,25 @@ namespace Aimmy2.AILogic
             };
         }
 
-        public static OnnxModelLoadResult Load(string modelPath, SessionOptions sessionOptions, bool useDirectML)
+        public static OnnxModelLoadResult Load(string modelPath, bool useDirectML)
         {
+            using SessionOptions sessionOptions = CreateDefaultOptions();
+
             if (useDirectML) { sessionOptions.AppendExecutionProvider_DML(); }
             else { sessionOptions.AppendExecutionProvider_CPU(); }
 
-            var session = new InferenceSession(modelPath, sessionOptions);
-            return new OnnxModelLoadResult(session, new List<string>(session.OutputMetadata.Keys));
+            InferenceSession? session = null;
+            try
+            {
+                session = new InferenceSession(modelPath, sessionOptions);
+                var result = new OnnxModelLoadResult(session, new List<string>(session.OutputMetadata.Keys));
+                session = null;
+                return result;
+            }
+            finally
+            {
+                session?.Dispose();
+            }
         }
     }
 

--- a/Aimmy2/AILogic/OnnxModelSessionFactory.cs
+++ b/Aimmy2/AILogic/OnnxModelSessionFactory.cs
@@ -1,0 +1,31 @@
+using Microsoft.ML.OnnxRuntime;
+
+namespace Aimmy2.AILogic
+{
+    internal static class OnnxModelSessionFactory
+    {
+        public static SessionOptions CreateDefaultOptions()
+        {
+            return new SessionOptions
+            {
+                EnableCpuMemArena = true,
+                EnableMemoryPattern = false,
+                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+                ExecutionMode = ExecutionMode.ORT_SEQUENTIAL,
+                InterOpNumThreads = 1,
+                IntraOpNumThreads = 4
+            };
+        }
+
+        public static OnnxModelLoadResult Load(string modelPath, SessionOptions sessionOptions, bool useDirectML)
+        {
+            if (useDirectML) { sessionOptions.AppendExecutionProvider_DML(); }
+            else { sessionOptions.AppendExecutionProvider_CPU(); }
+
+            var session = new InferenceSession(modelPath, sessionOptions);
+            return new OnnxModelLoadResult(session, new List<string>(session.OutputMetadata.Keys));
+        }
+    }
+
+    internal sealed record OnnxModelLoadResult(InferenceSession Session, List<string> OutputNames);
+}

--- a/Aimmy2/AILogic/OnnxModelSessionFactory.cs
+++ b/Aimmy2/AILogic/OnnxModelSessionFactory.cs
@@ -4,7 +4,7 @@ namespace Aimmy2.AILogic
 {
     internal static class OnnxModelSessionFactory
     {
-        public static SessionOptions CreateDefaultOptions()
+        private static SessionOptions CreateDefaultOptions()
         {
             return new SessionOptions
             {
@@ -17,7 +17,7 @@ namespace Aimmy2.AILogic
             };
         }
 
-        public static OnnxModelLoadResult Load(string modelPath, bool useDirectML)
+        internal static OnnxModelLoadResult Load(string modelPath, bool useDirectML)
         {
             using SessionOptions sessionOptions = CreateDefaultOptions();
 


### PR DESCRIPTION
## Summary
- Extract ONNX session option creation, provider selection, session creation, and output-name capture.
- Preserve DirectML-to-CPU fallback behavior and model-load lifecycle.
- Keep helper visibility internal/private where the code is not public API.

## Stack
- Depends on refactor/prediction-filter.
- This PR targets refactor/prediction-filter to keep the diff focused.

## Verification
- `dotnet run --project .\.rework-tests\ReviewHarness\ReviewHarness.csproj`
- `powershell -ExecutionPolicy Bypass -File .\.rework-tests\ReviewCleanupChecks.ps1`
- `dotnet build .\Aimmy2\Aimmy2.csproj -v:minimal`
- `git diff --check`
- Runtime smoke confirmed model/config load, toggles, capture, and aim loop behavior on the full stack.