### PR TITLE
refactor: add settings facade

### DIFF
--- a/Aimmy2/AILogic/AIManager.cs
+++ b/Aimmy2/AILogic/AIManager.cs
@@ -188,10 +188,10 @@ namespace Aimmy2.AILogic
         public AIManager(string modelPath)
         {
             // Initialize the cached image size
-            _currentImageSize = int.Parse(Dictionary.dropdownState["Image Size"]);
+            _currentImageSize = AimSettings.ImageSize;
 
             // Initialize DXGI capture for current display
-            if (Dictionary.dropdownState["Screen Capture Method"] == "DirectX")
+            if (AimSettings.ScreenCaptureMethod == "DirectX")
             {
                 _captureManager.InitializeDxgiDuplication();
             }
@@ -349,14 +349,14 @@ namespace Aimmy2.AILogic
                     NUM_DETECTIONS = CalculateNumDetections(fixedInputSize);
                     _currentImageSize = fixedInputSize;
 
-                    if (fixedInputSize != int.Parse(Dictionary.dropdownState["Image Size"]))
+                    if (fixedInputSize != AimSettings.ImageSize)
                     {
                         // Auto-adjust the image size to match the model
                         Log(LogLevel.Warning,
                             $"Fixed-size model expects {fixedInputSize}x{fixedInputSize}. Automatically adjusting Image Size setting.",
                             true, 3000);
 
-                        Dictionary.dropdownState["Image Size"] = fixedSizeStr;
+                        AimSettings.ImageSize = fixedInputSize;
 
                         // Update the UI dropdown if it exists
                         Application.Current?.Dispatcher.BeginInvoke(() =>
@@ -450,17 +450,17 @@ namespace Aimmy2.AILogic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ShouldPredict() =>
             AimProcessingDecisions.ShouldRunPrediction(
-                Dictionary.toggleState["Show Detected Player"],
-                Dictionary.toggleState["Constant AI Tracking"],
+                AimSettings.ShowDetectedPlayer,
+                AimSettings.ConstantAiTracking,
                 InputBindingManager.IsHoldingBinding("Aim Keybind"),
                 InputBindingManager.IsHoldingBinding("Second Aim Keybind"));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ShouldProcess() =>
             AimProcessingDecisions.ShouldProcessFrame(
-                Dictionary.toggleState["Aim Assist"],
-                Dictionary.toggleState["Show Detected Player"],
-                Dictionary.toggleState["Auto Trigger"]);
+                AimSettings.AimAssist,
+                AimSettings.ShowDetectedPlayer,
+                AimSettings.AutoTrigger);
 
         private async void AiLoop()
         {
@@ -549,24 +549,24 @@ namespace Aimmy2.AILogic
             // or if constant AI tracking is enabled,
             // we check for spray release and return
             if (!AimProcessingDecisions.ShouldAttemptAutoTrigger(
-                Dictionary.toggleState["Auto Trigger"],
+                AimSettings.AutoTrigger,
                 InputBindingManager.IsHoldingBinding("Aim Keybind"),
                 InputBindingManager.IsHoldingBinding("Second Aim Keybind"),
-                Dictionary.toggleState["Constant AI Tracking"]))
+                AimSettings.ConstantAiTracking))
             {
                 CheckSprayRelease();
                 return;
             }
 
 
-            if (Dictionary.toggleState["Spray Mode"])
+            if (AimSettings.SprayMode)
             {
                 await MouseManager.DoTriggerClick(LastDetectionBox);
                 return;
             }
 
 
-            if (Dictionary.toggleState["Cursor Check"])
+            if (AimSettings.CursorCheck)
             {
                 var mousePos = WinAPICaller.GetCursorPosition();
 
@@ -585,17 +585,17 @@ namespace Aimmy2.AILogic
                 await MouseManager.DoTriggerClick();
             }
 
-            if (!Dictionary.toggleState["Aim Assist"] || !Dictionary.toggleState["Show Detected Player"]) return;
+            if (!AimSettings.AimAssist || !AimSettings.ShowDetectedPlayer) return;
 
         }
         private void CheckSprayRelease()
         {
-            if (!Dictionary.toggleState["Spray Mode"]) return;
+            if (!AimSettings.SprayMode) return;
 
             // if auto trigger is disabled, we reset the spray state
             // if the aim keybinds are not held, we reset the spray state
             if (!AimProcessingDecisions.ShouldKeepSprayActive(
-                Dictionary.toggleState["Auto Trigger"],
+                AimSettings.AutoTrigger,
                 InputBindingManager.IsHoldingBinding("Aim Keybind"),
                 InputBindingManager.IsHoldingBinding("Second Aim Keybind")))
             {
@@ -605,7 +605,7 @@ namespace Aimmy2.AILogic
 
         private async void UpdateFOV()
         {
-            if (Dictionary.dropdownState["Detection Area Type"] == "Closest to Mouse" && Dictionary.toggleState["FOV"])
+            if (AimSettings.DetectionAreaType == "Closest to Mouse" && AimSettings.ShowFov)
             {
                 var mousePosition = WinAPICaller.GetCursorPosition();
 
@@ -629,16 +629,16 @@ namespace Aimmy2.AILogic
 
         private static void DisableOverlay(DetectedPlayerWindow DetectedPlayerOverlay)
         {
-            if (Dictionary.toggleState["Show Detected Player"] && Dictionary.DetectedPlayerOverlay != null)
+            if (AimSettings.ShowDetectedPlayer && Dictionary.DetectedPlayerOverlay != null)
             {
                 Application.Current.Dispatcher.Invoke(() =>
                 {
-                    if (Dictionary.toggleState["Show AI Confidence"])
+                    if (AimSettings.ShowAiConfidence)
                     {
                         DetectedPlayerOverlay!.DetectedPlayerConfidence.Opacity = 0;
                     }
 
-                    if (Dictionary.toggleState["Show Tracers"])
+                    if (AimSettings.ShowTracers)
                     {
                         DetectedPlayerOverlay!.DetectedTracers.Opacity = 0;
                     }
@@ -663,7 +663,7 @@ namespace Aimmy2.AILogic
 
             Application.Current.Dispatcher.Invoke(() =>
             {
-                if (Dictionary.toggleState["Show AI Confidence"])
+                if (AimSettings.ShowAiConfidence)
                 {
                     DetectedPlayerOverlay.DetectedPlayerConfidence.Opacity = 1;
                     DetectedPlayerOverlay.DetectedPlayerConfidence.Content = $"{closestPrediction.ClassName}: {Math.Round((AIConf * 100), 2)}%";
@@ -673,11 +673,11 @@ namespace Aimmy2.AILogic
                         centerX - labelEstimatedHalfWidth,
                         centerY - DetectedPlayerOverlay.DetectedPlayerConfidence.ActualHeight - 2, 0, 0);
                 }
-                var showTracers = Dictionary.toggleState["Show Tracers"];
+                var showTracers = AimSettings.ShowTracers;
                 DetectedPlayerOverlay.DetectedTracers.Opacity = showTracers ? 1 : 0;
                 if (showTracers)
                 {
-                    var tracerPosition = Dictionary.dropdownState["Tracer Position"];
+                    var tracerPosition = AimSettings.TracerPosition;
 
                     var boxTop = centerY;
                     var boxBottom = centerY + LastDetectionBox.Height;
@@ -722,7 +722,7 @@ namespace Aimmy2.AILogic
                     }
                 }
 
-                DetectedPlayerOverlay.Opacity = Dictionary.sliderSettings["Opacity"];
+                DetectedPlayerOverlay.Opacity = AimSettings.OverlayOpacity;
 
                 DetectedPlayerOverlay.DetectedPlayerFocus.Opacity = 1;
                 DetectedPlayerOverlay.DetectedPlayerFocus.Margin = new Thickness(
@@ -736,24 +736,24 @@ namespace Aimmy2.AILogic
         {
             AIConf = closestPrediction.Confidence;
 
-            if (Dictionary.toggleState["Show Detected Player"] && Dictionary.DetectedPlayerOverlay != null)
+            if (AimSettings.ShowDetectedPlayer && Dictionary.DetectedPlayerOverlay != null)
             {
                 using (Benchmark("UpdateOverlay"))
                 {
                     UpdateOverlay(DetectedPlayerOverlay!, closestPrediction);
                 }
-                if (!Dictionary.toggleState["Aim Assist"]) return;
+                if (!AimSettings.AimAssist) return;
             }
 
-            double YOffset = Dictionary.sliderSettings["Y Offset (Up/Down)"];
-            double XOffset = Dictionary.sliderSettings["X Offset (Left/Right)"];
+            double YOffset = AimSettings.YOffset;
+            double XOffset = AimSettings.XOffset;
 
-            double YOffsetPercentage = Dictionary.sliderSettings["Y Offset (%)"];
-            double XOffsetPercentage = Dictionary.sliderSettings["X Offset (%)"];
+            double YOffsetPercentage = AimSettings.YOffsetPercent;
+            double XOffsetPercentage = AimSettings.XOffsetPercent;
 
             var rect = closestPrediction.Rectangle;
 
-            if (Dictionary.toggleState["X Axis Percentage Adjustment"])
+            if (AimSettings.UseXAxisPercentageAdjustment)
             {
                 detectedX = (int)((rect.X + (rect.Width * (XOffsetPercentage / 100))) * scaleX);
             }
@@ -762,7 +762,7 @@ namespace Aimmy2.AILogic
                 detectedX = (int)((rect.X + rect.Width / 2) * scaleX + XOffset);
             }
 
-            if (Dictionary.toggleState["Y Axis Percentage Adjustment"])
+            if (AimSettings.UseYAxisPercentageAdjustment)
             {
                 detectedY = (int)((rect.Y + rect.Height - (rect.Height * (YOffsetPercentage / 100))) * scaleY + YOffset);
             }
@@ -779,7 +779,7 @@ namespace Aimmy2.AILogic
             float yBase = rect.Y;
             float yAdjustment = 0;
 
-            switch (Dictionary.dropdownState["Aiming Boundaries Alignment"])
+            switch (AimSettings.AimingBoundariesAlignment)
             {
                 case "Center":
                     yAdjustment = rect.Height / 2;
@@ -799,12 +799,12 @@ namespace Aimmy2.AILogic
 
         private void HandleAim(Prediction closestPrediction)
         {
-            if (Dictionary.toggleState["Aim Assist"] &&
-                (Dictionary.toggleState["Constant AI Tracking"] ||
-                 Dictionary.toggleState["Aim Assist"] && InputBindingManager.IsHoldingBinding("Aim Keybind") ||
-                 Dictionary.toggleState["Aim Assist"] && InputBindingManager.IsHoldingBinding("Second Aim Keybind")))
+            if (AimSettings.AimAssist &&
+                (AimSettings.ConstantAiTracking ||
+                 AimSettings.AimAssist && InputBindingManager.IsHoldingBinding("Aim Keybind") ||
+                 AimSettings.AimAssist && InputBindingManager.IsHoldingBinding("Second Aim Keybind")))
             {
-                if (Dictionary.toggleState["Predictions"])
+                if (AimSettings.Predictions)
                 {
                     HandlePredictions(kalmanPrediction, closestPrediction, detectedX, detectedY);
                 }
@@ -817,7 +817,7 @@ namespace Aimmy2.AILogic
 
         private void HandlePredictions(KalmanPrediction kalmanPrediction, Prediction closestPrediction, int detectedX, int detectedY)
         {
-            var predictionMethod = Dictionary.dropdownState["Prediction Method"];
+            var predictionMethod = AimSettings.PredictionMethod;
             switch (predictionMethod)
             {
                 case "Kalman Filter":
@@ -918,7 +918,7 @@ namespace Aimmy2.AILogic
                 }
 
                 // Calculate the FOV boundaries
-                float FovSize = (float)Dictionary.sliderSettings["FOV Size"];
+                float FovSize = (float)AimSettings.FovSize;
                 float fovMinX = (IMAGE_SIZE - FovSize) / 2.0f;
                 float fovMaxX = (IMAGE_SIZE + FovSize) / 2.0f;
                 float fovMinY = (IMAGE_SIZE - FovSize) / 2.0f;
@@ -928,8 +928,8 @@ namespace Aimmy2.AILogic
                 List<Prediction> KDPredictions;
                 using (Benchmark("PrepareKDTreeData"))
                 {
-                    float minConfidence = (float)Dictionary.sliderSettings["AI Minimum Confidence"] / 100.0f;
-                    string selectedClass = Dictionary.dropdownState["Target Class"];
+                    float minConfidence = AimSettings.MinimumConfidence;
+                    string selectedClass = AimSettings.TargetClass;
 
                     KDPredictions = PredictionFilter.CreatePredictions(
                         outputTensor,
@@ -973,8 +973,8 @@ namespace Aimmy2.AILogic
                 }
 
                 Prediction? finalTarget = _stickyAimSelector.SelectTarget(
-                    Dictionary.toggleState["Sticky Aim"],
-                    (float)Dictionary.sliderSettings["Sticky Aim Threshold"],
+                    AimSettings.StickyAim,
+                    (float)AimSettings.StickyAimThreshold,
                     IMAGE_SIZE,
                     bestCandidate,
                     KDPredictions);
@@ -997,7 +997,7 @@ namespace Aimmy2.AILogic
 
         private Rectangle CreateDetectionBox()
         {
-            string detectionAreaType = Dictionary.dropdownState["Detection Area Type"];
+            string detectionAreaType = AimSettings.DetectionAreaType;
             System.Drawing.Point mousePosition = default;
             bool mouseOnCurrentDisplay = false;
 
@@ -1041,10 +1041,10 @@ namespace Aimmy2.AILogic
         private void SaveFrame(Bitmap frame, Prediction? DoLabel = null)
         {
             // Only save frames if "Collect Data While Playing" is enabled
-            if (!Dictionary.toggleState["Collect Data While Playing"]) return;
+            if (!AimSettings.CollectDataWhilePlaying) return;
 
             // Skip if we're in constant tracking mode (unless auto-labeling is enabled)
-            if (Dictionary.toggleState["Constant AI Tracking"] && !Dictionary.toggleState["Auto Label Data"]) return;
+            if (AimSettings.ConstantAiTracking && !AimSettings.AutoLabelData) return;
 
             // Cooldown check
             if ((DateTime.Now - lastSavedTime).TotalMilliseconds < SAVE_FRAME_COOLDOWN_MS) return;
@@ -1066,7 +1066,7 @@ namespace Aimmy2.AILogic
                 // Save synchronously to avoid "Object is currently in use elsewhere" error
                 frame.Save(imagePath, ImageFormat.Jpeg);
 
-                if (Dictionary.toggleState["Auto Label Data"] && DoLabel != null)
+                if (AimSettings.AutoLabelData && DoLabel != null)
                 {
                     var labelPath = Path.Combine("bin", "labels", $"{uuid}.txt");
 

--- a/Aimmy2/AILogic/CaptureManager.cs
+++ b/Aimmy2/AILogic/CaptureManager.cs
@@ -227,7 +227,7 @@ namespace AILogic
                 _directXFailedPermanently = true;
                 DisposeDxgiResources();
 
-                Dictionary.dropdownState["Screen Capture Method"] = "GDI+";
+                AimSettings.ScreenCaptureMethod = "GDI+";
                 _currentCaptureMethod = "GDI+";
 
                 LogManager.Log(LogLevel.Error, "DirectX Desktop Duplication not supported on this system. Switched to GDI+ capture.", true, 6000);
@@ -389,7 +389,7 @@ namespace AILogic
                                 dst += dstStride;
                             }
 
-                            if (Dictionary.toggleState["Third Person Support"]) // a mask basically
+                            if (AimSettings.ThirdPersonSupport) // a mask basically
                             {
                                 int width = w / 2;
                                 int height = h / 2;
@@ -504,7 +504,7 @@ namespace AILogic
                         CopyPixelOperation.SourceCopy
                     );
 
-                    if (Dictionary.toggleState["Third Person Support"])
+                    if (AimSettings.ThirdPersonSupport)
                     {
                         int width = screenCaptureBitmap.Width / 2;
                         int height = screenCaptureBitmap.Height / 2;
@@ -530,12 +530,12 @@ namespace AILogic
 
         public Bitmap? ScreenGrab(Rectangle detectionBox)
         {
-            string selectedMethod = Dictionary.dropdownState["Screen Capture Method"];
+            string selectedMethod = AimSettings.ScreenCaptureMethod;
 
             // If DirectX failed permanently, force GDI+
             if (_directXFailedPermanently && selectedMethod == "DirectX")
             {
-                Dictionary.dropdownState["Screen Capture Method"] = "GDI+";
+                AimSettings.ScreenCaptureMethod = "GDI+";
                 selectedMethod = "GDI+";
                 _currentCaptureMethod = "GDI+";
             }

--- a/Aimmy2/AILogic/PredictionManager.cs
+++ b/Aimmy2/AILogic/PredictionManager.cs
@@ -90,7 +90,7 @@ namespace AILogic
             double currentY = _y + _vy * dt;
 
             // Get base lead time from settings
-            double leadTime = (double)Dictionary.sliderSettings["Kalman Lead Time"];
+            double leadTime = AimSettings.KalmanLeadTime;
 
             // Dynamically adjust based on mouse speed if available
             if (mouseSpeed > 0.0)
@@ -191,7 +191,7 @@ namespace AILogic
         public WTFDetection GetEstimatedPosition()
         {
             // Get lead time from settings
-            double leadTime = (double)Dictionary.sliderSettings["WiseTheFox Lead Time"];
+            double leadTime = AimSettings.WiseTheFoxLeadTime;
 
             // Predict where target will be after lead time
             double predictedX = _emaX + _velocityX * leadTime;
@@ -267,7 +267,7 @@ namespace AILogic
             }
 
             // Get lead multiplier from settings
-            double leadMultiplier = (double)Dictionary.sliderSettings["Shalloe Lead Multiplier"];
+            double leadMultiplier = AimSettings.ShalloeLeadMultiplier;
 
             // Calculate average velocity
             double avgVelocity = _velocityXHistory.Average();
@@ -284,7 +284,7 @@ namespace AILogic
             }
 
             // Get lead multiplier from settings
-            double leadMultiplier = (double)Dictionary.sliderSettings["Shalloe Lead Multiplier"];
+            double leadMultiplier = AimSettings.ShalloeLeadMultiplier;
 
             // Calculate average velocity
             double avgVelocity = _velocityYHistory.Average();

--- a/Aimmy2/Class/AimSettings.cs
+++ b/Aimmy2/Class/AimSettings.cs
@@ -1,0 +1,73 @@
+using System.Globalization;
+
+namespace Aimmy2.Class
+{
+    internal static class AimSettings
+    {
+        public static int ImageSize
+        {
+            get => int.Parse(GetDropdown("Image Size"), CultureInfo.InvariantCulture);
+            set => SetDropdown("Image Size", value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static string ScreenCaptureMethod
+        {
+            get => GetDropdown("Screen Capture Method");
+            set => SetDropdown("Screen Capture Method", value);
+        }
+
+        public static string DetectionAreaType => GetDropdown("Detection Area Type");
+        public static string TargetClass => GetDropdown("Target Class");
+        public static string PredictionMethod => GetDropdown("Prediction Method");
+        public static string AimingBoundariesAlignment => GetDropdown("Aiming Boundaries Alignment");
+        public static string TracerPosition => GetDropdown("Tracer Position");
+        public static string MovementPath => GetDropdown("Movement Path");
+        public static string MouseMovementMethod => GetDropdown("Mouse Movement Method");
+
+        public static double FovSize => GetSlider("FOV Size");
+        public static float MinimumConfidence => (float)(GetSlider("AI Minimum Confidence") / 100.0);
+        public static double StickyAimThreshold => GetSlider("Sticky Aim Threshold");
+        public static double OverlayOpacity => GetSlider("Opacity");
+        public static double YOffset => GetSlider("Y Offset (Up/Down)");
+        public static double XOffset => GetSlider("X Offset (Left/Right)");
+        public static double YOffsetPercent => GetSlider("Y Offset (%)");
+        public static double XOffsetPercent => GetSlider("X Offset (%)");
+        public static int AutoTriggerDelayMilliseconds => (int)(GetSlider("Auto Trigger Delay") * 1000);
+        public static int MouseJitter => (int)GetSlider("Mouse Jitter");
+        public static double MouseSensitivity => GetSlider("Mouse Sensitivity (+/-)");
+        public static double KalmanLeadTime => GetSlider("Kalman Lead Time");
+        public static double WiseTheFoxLeadTime => GetSlider("WiseTheFox Lead Time");
+        public static double ShalloeLeadMultiplier => GetSlider("Shalloe Lead Multiplier");
+
+        public static bool AutoTrigger => GetToggle("Auto Trigger");
+        public static bool ConstantAiTracking => GetToggle("Constant AI Tracking");
+        public static bool SprayMode => GetToggle("Spray Mode");
+        public static bool CursorCheck => GetToggle("Cursor Check");
+        public static bool AimAssist => GetToggle("Aim Assist");
+        public static bool ShowDetectedPlayer => GetToggle("Show Detected Player");
+        public static bool ShowFov => GetToggle("FOV");
+        public static bool ShowAiConfidence => GetToggle("Show AI Confidence");
+        public static bool ShowTracers => GetToggle("Show Tracers");
+        public static bool UseXAxisPercentageAdjustment => GetToggle("X Axis Percentage Adjustment");
+        public static bool UseYAxisPercentageAdjustment => GetToggle("Y Axis Percentage Adjustment");
+        public static bool Predictions => GetToggle("Predictions");
+        public static bool StickyAim => GetToggle("Sticky Aim");
+        public static bool CollectDataWhilePlaying => GetToggle("Collect Data While Playing");
+        public static bool AutoLabelData => GetToggle("Auto Label Data");
+        public static bool ThirdPersonSupport => GetToggle("Third Person Support");
+
+        public static double GetSlider(string key) =>
+            Convert.ToDouble(Dictionary.sliderSettings[key], CultureInfo.InvariantCulture);
+
+        public static bool GetToggle(string key) =>
+            Convert.ToBoolean(Dictionary.toggleState[key], CultureInfo.InvariantCulture);
+
+        public static string GetDropdown(string key) =>
+            Convert.ToString(Dictionary.dropdownState[key], CultureInfo.InvariantCulture) ?? string.Empty;
+
+        private static void SetDropdown(string key, string value)
+        {
+            Dictionary.dropdownState[key] = value;
+        }
+    }
+}

--- a/Aimmy2/InputLogic/MouseManager.cs
+++ b/Aimmy2/InputLogic/MouseManager.cs
@@ -35,7 +35,7 @@ namespace InputLogic
         // Cleanup
         private static (Action down, Action up) GetMouseActions()
         {
-            string mouseMovementMethod = Dictionary.dropdownState["Mouse Movement Method"];
+            string mouseMovementMethod = AimSettings.MouseMovementMethod;
             Action mouseDownAction;
             Action mouseUpAction;
 
@@ -76,9 +76,9 @@ namespace InputLogic
             }
 
 
-            if (Dictionary.toggleState["Spray Mode"])
+            if (AimSettings.SprayMode)
             {
-                if (Dictionary.toggleState["Cursor Check"])
+                if (AimSettings.CursorCheck)
                 {
                     Point mousePos = WinAPICaller.GetCursorPosition();
 
@@ -95,7 +95,7 @@ namespace InputLogic
 
             // Single click logic if spray mode off
             int timeSinceLastClick = (int)(DateTime.UtcNow - LastClickTime).TotalMilliseconds;
-            int triggerDelayMilliseconds = (int)(Dictionary.sliderSettings["Auto Trigger Delay"] * 1000);
+            int triggerDelayMilliseconds = AimSettings.AutoTriggerDelayMilliseconds;
             const int clickDelayMilliseconds = 20;
 
             if (timeSinceLastClick < triggerDelayMilliseconds && LastClickTime != DateTime.MinValue)
@@ -150,7 +150,7 @@ namespace InputLogic
 
             double aspectRatioCorrection = ScreenWidth / ScreenHeight;
 
-            int MouseJitter = (int)Dictionary.sliderSettings["Mouse Jitter"];
+            int MouseJitter = AimSettings.MouseJitter;
             int jitterX = MouseRandom.Next(-MouseJitter, MouseJitter);
             int jitterY = MouseRandom.Next(-MouseJitter, MouseJitter);
 
@@ -158,27 +158,27 @@ namespace InputLogic
             Point end = new(targetX, targetY);
             Point newPosition = new Point(0, 0);
 
-            switch (Dictionary.dropdownState["Movement Path"])
+            switch (AimSettings.MovementPath)
             {
                 case "Cubic Bezier":
                     Point control1 = new Point(start.X + (end.X - start.X) / 3, start.Y + (end.Y - start.Y) / 3);
                     Point control2 = new Point(start.X + 2 * (end.X - start.X) / 3, start.Y + 2 * (end.Y - start.Y) / 3);
-                    newPosition = MovementPaths.CubicBezier(start, end, control1, control2, 1 - Dictionary.sliderSettings["Mouse Sensitivity (+/-)"]);
+                    newPosition = MovementPaths.CubicBezier(start, end, control1, control2, 1 - AimSettings.MouseSensitivity);
                     break;
                 case "Linear":
-                    newPosition = MovementPaths.Lerp(start, end, 1 - Dictionary.sliderSettings["Mouse Sensitivity (+/-)"]);
+                    newPosition = MovementPaths.Lerp(start, end, 1 - AimSettings.MouseSensitivity);
                     break;
                 case "Exponential":
-                    newPosition = MovementPaths.Exponential(start, end, 1 - (Dictionary.sliderSettings["Mouse Sensitivity (+/-)"] - 0.2), 3.0);
+                    newPosition = MovementPaths.Exponential(start, end, 1 - (AimSettings.MouseSensitivity - 0.2), 3.0);
                     break;
                 case "Adaptive":
-                    newPosition = MovementPaths.Adaptive(start, end, 1 - Dictionary.sliderSettings["Mouse Sensitivity (+/-)"]);
+                    newPosition = MovementPaths.Adaptive(start, end, 1 - AimSettings.MouseSensitivity);
                     break;
                 case "Perlin Noise":
-                    newPosition = MovementPaths.PerlinNoise(start, end, 1 - Dictionary.sliderSettings["Mouse Sensitivity (+/-)"], 20, 0.5);
+                    newPosition = MovementPaths.PerlinNoise(start, end, 1 - AimSettings.MouseSensitivity, 20, 0.5);
                     break;
                 default:
-                    newPosition = MovementPaths.Lerp(start, end, 1 - Dictionary.sliderSettings["Mouse Sensitivity (+/-)"]);
+                    newPosition = MovementPaths.Lerp(start, end, 1 - AimSettings.MouseSensitivity);
                     break;
             }
 
@@ -196,7 +196,7 @@ namespace InputLogic
             newPosition.X += jitterX;
             newPosition.Y += jitterY;
 
-            switch (Dictionary.dropdownState["Mouse Movement Method"])
+            switch (AimSettings.MouseMovementMethod)
             {
                 case "SendInput":
                     SendInputMouse.SendMouseCommand(MOUSEEVENTF_MOVE, newPosition.X, newPosition.Y);
@@ -222,7 +222,7 @@ namespace InputLogic
             previousX = newPosition.X;
             previousY = newPosition.Y;
 
-            if (!Dictionary.toggleState["Auto Trigger"])
+            if (!AimSettings.AutoTrigger)
             {
                 ResetSprayState();
             }


### PR DESCRIPTION
## Summary
- Add an app-internal AimSettings facade over the existing settings dictionaries.
- Move AI, capture, prediction, and input settings reads through typed properties.
- Keep UI and persistence paths on the existing dictionary/config contract.

## Stack
- Depends on refactor/capture-boundary.
- This PR targets refactor/capture-boundary to keep the diff focused.

## Verification
- `dotnet run --project .\.rework-tests\ReviewHarness\ReviewHarness.csproj`
- `powershell -ExecutionPolicy Bypass -File .\.rework-tests\ReviewCleanupChecks.ps1`
- `dotnet build .\Aimmy2\Aimmy2.csproj -v:minimal`
- `git diff --check`
- Runtime smoke confirmed model/config load, toggles, capture, and aim loop behavior on the full stack.