### PR TITLE
fix: repair validate-assets workflow YAML

### DIFF
--- a/.github/workflows/validate-assets.yml
+++ b/.github/workflows/validate-assets.yml
@@ -58,17 +58,19 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `## ❌ Invalid File Types
-
-No valid \`.onnx\` or \`.cfg\` files found.
-
-**Files uploaded:** ${fileList}
-
-**Required:**
-- Models: \`.onnx\` files in \`models/\` folder
-- Configs: \`.cfg\` files in \`configs/\` folder
-
-This PR has been automatically closed.`
+              body: [
+                '## ❌ Invalid File Types',
+                '',
+                'No valid `.onnx` or `.cfg` files found.',
+                '',
+                `**Files uploaded:** ${fileList}`,
+                '',
+                '**Required:**',
+                '- Models: `.onnx` files in `models/` folder',
+                '- Configs: `.cfg` files in `configs/` folder',
+                '',
+                'This PR has been automatically closed.'
+              ].join('\n')
             });
 
             await github.rest.pulls.update({


### PR DESCRIPTION
## Summary
- replace the invalid multiline template literal in validate-assets with a YAML-safe joined string array
- keep the invalid-file comment text and workflow behavior the same

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/validate-assets.yml`
- `git diff --check`