### PR TITLE
ci: limit desktop build triggers

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -4,11 +4,26 @@ name: .NET Core Desktop
 on:
   push:
     branches: [ "Aimmy-V2" ]
+    paths:
+      - 'Aimmy2/**'
+      - 'Aimmy2.sln'
+      - '**/*.csproj'
+      - '**/*.props'
+      - '**/*.targets'
+      - 'global.json'
+      - 'NuGet.config'
+      - '.github/workflows/dotnet-desktop.yml'
   pull_request:
     branches: [ "Aimmy-V2" ]
-    paths-ignore:
-      - 'models/**'
-      - 'configs/**'
+    paths:
+      - 'Aimmy2/**'
+      - 'Aimmy2.sln'
+      - '**/*.csproj'
+      - '**/*.props'
+      - '**/*.targets'
+      - 'global.json'
+      - 'NuGet.config'
+      - '.github/workflows/dotnet-desktop.yml'
 
 jobs:
 


### PR DESCRIPTION
## Summary
- replace the broad desktop build PR trigger with explicit app/build input paths
- apply the same path filter to pushes into Aimmy-V2
- keep the desktop build running when its own workflow changes

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dotnet-desktop.yml`
- `git diff --check`